### PR TITLE
Adding in several Missing Core Rules 

### DIFF
--- a/Special Rules.cat
+++ b/Special Rules.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="106b-693b-99f2-00c3" name="Special Rules" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="2" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue library="true" id="106b-693b-99f2-00c3" name="Special Rules" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="3" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedRules>
     <rule name="Interdiction Cadres" id="a752-1dc3-403e-9336" hidden="false"/>
     <rule name="Concealed Positions" id="3595-4991-0833-7b8b" hidden="false"/>
@@ -66,6 +66,56 @@ In Step 3 of the Challenge Sub-Phase, the Focus Step, if a Player has declared t
     <rule name="Battlesmith (X)" id="c3db-d17c-fd46-eb01" hidden="false"/>
     <rule name="Master of Automata" id="3ad7-36d0-16cc-4995" hidden="false"/>
     <rule name="Infiltrate (X)" id="f330-254e-1a98-798a" hidden="false"/>
+    <rule name="Armour-Breaker (X)" id="3009-9bbb-a8f6-1b47" hidden="false">
+      <comment>Needs Rule</comment>
+    </rule>
+    <rule name="Assault Vehicle" id="150c-16e6-1212-9f75" hidden="false" publicationId="7d63-5df4-c656-52de" page="326">
+      <description>&quot;A Vehicle with this Special Rule allows Models to Disembark and Charge without penalty.&quot;
+A Unit that is Disembarked from another Model that has the Assault Vehicle Special Rule may have a Charge declared for it in the Charge Sub-Phase of the same Player Turn without being forced to make a Disordered Charge.</description>
+    </rule>
+    <rule name="Bitter Duty" id="5d6f-552a-f409-cad5" hidden="false">
+      <comment>Needs Rule</comment>
+    </rule>
+    <rule name="Eternal Warrior (X)" id="15b4-9e4a-f361-c5a3" hidden="false" publicationId="7d63-5df4-c656-52de" page="329">
+      <description>&quot;A Model with this Special Rule takes less Damage from attacks.&quot;
+When a Model with the Eternal Warrior (X) Special Rule is allocated an Unsaved Wound, the Damage of the Unsaved Wound is reduced by the value of X attached to the specific variant of the Eternal Warrior (X) Special Rule. The effects of this Special Rule cannot reduce the Damage of an Unsaved Wound to less than 1, regardless of the value of X.</description>
+    </rule>
+    <rule name="Fast (X)" id="9ebf-3b90-be22-b9c2" hidden="false" publicationId="7d63-5df4-c656-52de" page="330">
+      <description>&quot;A Unit that only includes Models with the Fast (X) Special Rule gain a bonus to Rush and Charge Moves.&quot;
+When the Player controlling a Unit that is composed entirely of Models with the Fast (X) Special Rule elects to have that Unit Rush, add the value of X attached to the specific variant of Fast (X) to the distance the Unit can move. Likewise, when a Unit composed entirely of Models with the Fast (X) Special Rule is required to make a Charge Move, add the value of X attached to the specific variant of the Fast (X) Special Rule as a positive modifier to the Charge Roll. In any situation where a Unit includes Models with two or more variants of the Fast (X) Special Rule, the lowest possible modifier is used.</description>
+    </rule>
+    <rule name="Firestorm" id="3ed1-c5b3-a98d-1b12" hidden="false">
+      <comment>Needs Rule</comment>
+    </rule>
+    <rule name="Firing Protocols (X)" id="84f2-5a93-c2eb-826f" hidden="false" publicationId="7d63-5df4-c656-52de" page="331">
+      <description>&quot;A Model with the Firing Protocols (X) Special Rule may attack with more than one ranged Weapon.&quot;
+A Model with the Firing Protocols (X) Special Rule that makes attacks as part of a Shooting Attack, may make attacks with a number of Weapons equal to the value of X attached to the specific variant of the Firing Protocols (X) Special Rule. The Model must have more than one Ranged Weapon to make use of this Special Rule and may not use the same Weapon more than once in the same Shooting Attack.</description>
+    </rule>
+    <rule name="Hatred (X)" id="0612-95d5-46ae-c5ee" hidden="false" publicationId="7d63-5df4-c656-52de" page="331">
+      <description>&quot;The Hatred (X) Special Rule grants bonuses against enemies of a specific Faction, Type or Trait.&quot;
+When Locked in Combat, or Engaged in a Challenge, with any enemy Models that have the Type or Trait that is the value of X, then all Models with this variant of the Hatred (X) Special Rule gain a bonus of +1 to all Wound Tests made in that Combat.</description>
+    </rule>
+    <rule name="Heedless" id="a3f3-72c6-7e01-6cab" hidden="false" publicationId="7d63-5df4-c656-52de" page="332">
+      <description>&quot;A Unit that includes any Models with this Special Rule cannot claim Objectives.&quot;
+A Unit that includes any Models with this Special Rule cannot Control or Contest any Object Marker - this overrides any other Rule or Special Rule that may apply to the Unit regardless of the source of the Rule or effect.</description>
+    </rule>
+    <rule name="Line (X)" id="633c-b81e-f302-85e0" hidden="false">
+      <comment>Needs Rule</comment>
+    </rule>
+    <rule name="Move Through Cover" id="44d9-f20d-00bf-dc98" hidden="false" publicationId="7d63-5df4-c656-52de" page="333">
+      <description>&quot;The Move Through Cover Special Rule allows the penalties of terrain to be ignored.&quot;
+A Unit that includes at least one Model with the Move Through Cover Special Rule ignores the effects of Difficult Terrain and Dangerous Terrain. If called upon to take a Dangerous Terrain Test then such a Unit is assumed to automatically pass without any Dice being rolled.</description>
+    </rule>
+    <rule name="Outflank" id="92d2-cc57-1ef6-a712" hidden="false">
+      <comment>Needs Rule</comment>
+    </rule>
+    <rule name="Shrouded (X)" id="c7e7-3bad-3de0-d6cc" hidden="false" publicationId="7d63-5df4-c656-52de" page="337">
+      <description>&quot;Shrouded (X) is a Damage Mitigation Test that may be taken in addition to a Saving Throw.&quot;
+A model with the Shrouded (X) Special Rule gains a Shrouded Damage Mitigation Test that may be used in Step 9 of the Shooting Attack process to discard Wounds allocated to the Model. A Damage Mitigation Test may be made after and in addition to a Saving Throw. The Target Number for a Shrouded Damage Mitigation Test is the value of X attached to the specific variant of the Special Rule. A Shrouded Damage Mitigation Test may not be made against wounds inflicted by a Melee Weapon.</description>
+    </rule>
+    <rule name="Vanguard (X)" id="530f-b733-993c-ec84" hidden="false" publicationId="7d63-5df4-c656-52de" page="339">
+      <comment>Needs Rule</comment>
+    </rule>
   </sharedRules>
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Telepathy" hidden="false" id="e09e-1438-3205-2a57"/>


### PR DESCRIPTION
This addresses Issue #17 and adds in these rules to the `Special Rules` catalog. I have included some of the shorter rule's text, with the bolded sections in `"`. If NR does accept MarkDown, we could actually bold these using wrapping `**`.