### PR TITLE
Warnings. Remove stray "crusade" chart from TS

### DIFF
--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="4" type="gameSystem" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<gameSystem id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="5" type="gameSystem" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <categoryEntries>
     <categoryEntry name="Officer of the Line (2)" id="901a-6b71-7a29-4597" hidden="false"/>
     <categoryEntry name="Allegiance" id="c408-52f1-b632-4c82" hidden="false"/>
@@ -226,7 +226,7 @@
     <categoryEntry name="Crux Magisterium" id="9501-add0-621d-f40f" hidden="true"/>
   </categoryEntries>
   <forceEntries>
-    <forceEntry name="Crusade Force Organization Chart" id="8562-592c-8d4b-a1f0" hidden="false" childForcesLabel="Auxillary and Apex Detachments" sortIndex="1">
+    <forceEntry name="Crusade Force Organization Chart" id="8562-592c-8d4b-a1f0" hidden="false" childForcesLabel="Detachments" sortIndex="1">
       <forceEntries>
         <forceEntry name="Crusade Primary Detachment" id="8f12-c30a-6c20-6296" hidden="true" sortIndex="1">
           <categoryLinks>
@@ -2932,9 +2932,9 @@
         </categoryLink>
       </categoryLinks>
     </forceEntry>
-    <forceEntry name="Allied Detachment" id="256b-b8a8-017a-75e9" hidden="false" childForcesLabel="Auxillary Detachments" sortIndex="2">
+    <forceEntry name="Allied Detachment" id="256b-b8a8-017a-75e9" hidden="false" childForcesLabel="Detachments" sortIndex="2">
       <forceEntries>
-        <forceEntry name="Allied Detachment " id="7469-bbd2-a2ad-f8a8" hidden="false" childForcesLabel="Auxillary Detachments" sortIndex="1">
+        <forceEntry name="Allied Detachment " id="7469-bbd2-a2ad-f8a8" hidden="false" childForcesLabel="Detachments" sortIndex="1">
           <categoryLinks>
             <categoryLink name="Command" hidden="false" id="772e-aee9-2bf8-b30d" targetId="6dbf-654a-f06f-2d69">
               <modifiers>
@@ -4382,6 +4382,23 @@
       <categoryLinks>
         <categoryLink name="Allegiance" hidden="false" id="5a4a-744e-eecc-1e4a" targetId="c408-52f1-b632-4c82" primary="true"/>
       </categoryLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Getting Started - Add the crusade primary detachment from the detachments section." hidden="false" id="8343-6431-55a2-fa6e" defaultAmount="1"/>
+    <selectionEntry type="upgrade" import="true" name="DON&apos;T SUBMIT BUGS FOR NOT IMPLEMENTED FUNCTIONALITY. See export for list." hidden="false" id="cd4a-d335-2d3a-91e0" defaultAmount="1">
+      <rules>
+        <rule name="Things that aren&apos;t implemented" id="10ac-cafa-6c21-0fa3" hidden="false">
+          <description>Knights
+Solar Aux
+A lot of detachment validation beyond the basic ones.
+Legion primes and legion wargear.
+
+
+A ton of other small stuff.
+
+
+Please don&apos;t submit bug reports for any of these things</description>
+        </rule>
+      </rules>
     </selectionEntry>
   </selectionEntries>
   <publications>

--- a/Thousand Sons.cat
+++ b/Thousand Sons.cat
@@ -2117,7 +2117,4 @@ Invulnerable Saves may be taken against these wounds as normal and these wounds
 If a Unit that has a Prosperine Arcana is granted a Psychic Weapon, only one Model in that Unit may use that Psychic Weapon each time that Unit is selected to make attacks as part of a Shooting Attack or a Combat.</description>
     </rule>
   </sharedRules>
-  <forceEntries>
-    <forceEntry name="Crusade Force Organization Chart" id="9863-e315-c4d7-2078" hidden="false" childForcesLabel="Auxillary and Apex Detachments"/>
-  </forceEntries>
 </catalogue>


### PR DESCRIPTION
Lets get some big old warnings:
<img width="1321" height="912" alt="image" src="https://github.com/user-attachments/assets/1987e2d8-a578-417c-ad8a-087965396b68" />
<img width="728" height="292" alt="image" src="https://github.com/user-attachments/assets/82fca9e3-5e93-441b-bd3b-9054f12b3995" />
