### PR TITLE
Category standardisation LA

### DIFF
--- a/Alpha Legion.cat
+++ b/Alpha Legion.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="8813-5298-c368-ee16" name="                       XX - Alpha Legion" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="8813-5298-c368-ee16" name="                       XX - Alpha Legion" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="6" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Armillus Dynat" hidden="false" id="df2e-ee83-e5e5-c333" sortIndex="2">
       <selectionEntries>
@@ -1243,274 +1243,41 @@ A Model with this Special Rule is always considered to be 2&quot; further away t
       </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
-  <forceEntries>
-    <forceEntry name="Auxiliary - Headhunter Leviathal" id="aaea-8b65-0abf-c91b" hidden="false">
-      <categoryLinks>
-        <categoryLink name="Elites" hidden="false" id="ab5a-8e09-2588-dd81" targetId="5d5e-958f-e388-50b5">
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="9a16-25f6-a70a-02f9"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="9a16-25f6-a70a-02f9">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="d81c-494b-0302-5844" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Elites" hidden="false" id="64de-1603-65ec-5796" targetId="276f-7a07-a56c-affd">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="802b-5333-d4c0-e8b4"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Recon" hidden="false" id="4f78-7b00-e5b5-b920" targetId="2b65-a3f2-620a-dc58">
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="5d91-48d7-6907-8a29"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="5d91-48d7-6907-8a29">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="a166-27df-d75c-bdb0" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Recon" hidden="false" id="afca-af3b-7c0c-58e3" targetId="6348-ecd0-714d-042a">
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="60df-59f0-4164-e147"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Retinue" hidden="false" id="76a5-0c1c-264e-c540" targetId="a38e-50ff-310f-f19e">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="9ce2-e832-5e64-92ea"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="9ce2-e832-5e64-92ea">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="e788-1cee-dabe-1e19" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="e788-1cee-dabe-1e19" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Retinue" hidden="false" id="ec12-2c96-b767-b9e4" targetId="c66b-ef39-b20f-725b">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="c629-ce85-60fc-95d3"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="War-engine" hidden="false" id="ed9b-d79a-7cb3-c5fb" targetId="2499-7239-685f-8465">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="7908-9cbe-a8d5-ccc7"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="7908-9cbe-a8d5-ccc7">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="fac3-0af2-8be3-20dc" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="fac3-0af2-8be3-20dc" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime War-engine" hidden="false" id="c182-4c5b-2b1b-2104" targetId="9699-67c9-2c0b-e64b">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="cda4-0317-d0d9-0c14"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Troops" hidden="false" id="0afe-6667-6442-68ba" targetId="88e6-d373-4152-0dd8">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="554e-8170-8bde-63e7"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="554e-8170-8bde-63e7">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="9e8c-63b6-a15a-cd4f" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="9e8c-63b6-a15a-cd4f" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Troops" hidden="false" id="3e49-f8fd-1677-ca68" targetId="c3f9-a7f3-984b-3fda">
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="68c4-b129-7ec5-b635" includeChildSelections="true"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Support" hidden="false" id="4888-a2cf-f6db-aefd" targetId="345f-9ba6-9b02-ed5c">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="da1a-f2e6-2a5c-39cc"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="da1a-f2e6-2a5c-39cc">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="18ed-afc2-ec5d-9f8c" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="18ed-afc2-ec5d-9f8c" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Support" hidden="false" id="dd02-0c9e-ef0c-380b" targetId="1c79-ecdf-9a64-84c9">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="7880-ea44-e477-8c26"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Transport" hidden="false" id="b081-7aa9-b562-2c2b" targetId="d162-4711-5d60-0a48">
-          <constraints>
-            <constraint type="max" value="4" field="selections" scope="parent" shared="true" id="541e-9e98-0298-2f58"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="541e-9e98-0298-2f58">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="861f-723a-938e-bc2c" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="861f-723a-938e-bc2c" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Transport" hidden="false" id="a2d0-304e-f447-399a" targetId="fc27-1a48-84ae-aa7b">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="6e23-9e80-f676-f1d9"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Heavy Assault" hidden="false" id="1bf7-b93a-c7fb-0560" targetId="3235-bd79-e9b1-60fa">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="97d7-6267-f7e0-98cf"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="97d7-6267-f7e0-98cf">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="5da8-2289-4e20-649f" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="5da8-2289-4e20-649f" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Heavy Assault" hidden="false" id="e170-b556-3c2e-738f" targetId="1e95-35f0-1353-ffa1">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="26b1-3c84-02fa-b45a"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Heavy Transport" hidden="false" id="a939-9033-697d-b8bd" targetId="52d0-8b78-439e-18e5">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="d633-ed1a-d8fb-ee41"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="d633-ed1a-d8fb-ee41">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="ad55-0e60-66fe-a7a9" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="ad55-0e60-66fe-a7a9" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Heavy Transport" hidden="false" id="bd41-74d9-f1d9-8c93" targetId="abff-3686-c39a-9a24">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="cb72-00d3-283a-f4e8"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Armour" hidden="false" id="53c4-0636-1f2d-45f9" targetId="643a-1012-bd51-6537">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="128c-2afb-54ea-6015"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="128c-2afb-54ea-6015">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="d5b0-22dc-909e-415e" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="d5b0-22dc-909e-415e" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Armour" hidden="false" id="267b-5261-405d-f831" targetId="4460-7bc1-4d80-aecb">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="1b52-70d5-1ea3-8eb1"/>
-          </constraints>
-        </categoryLink>
-        <categoryLink name="Fast Attack" hidden="false" id="b3b6-57db-c19d-27f7" targetId="cf96-8891-3f9a-8921">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="6f80-95e9-4cb7-2aa2"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="1" field="6f80-95e9-4cb7-2aa2">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="force" childId="cf0d-0aff-8242-f25a" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="equalTo" value="0" field="selections" scope="force" childId="cf0d-0aff-8242-f25a" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </categoryLink>
-        <categoryLink name="Prime Fast Attack" hidden="false" id="2760-dcb0-1721-f119" targetId="c291-144b-3da6-37ed">
-          <constraints>
-            <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="1993-1788-f7cf-73ca"/>
-          </constraints>
-        </categoryLink>
-      </categoryLinks>
-      <comment>Needs restrictions for Seeker and Headhunter put in</comment>
-    </forceEntry>
-  </forceEntries>
   <entryLinks>
     <entryLink import="true" name="Deathwing Companion Detachment" hidden="false" id="7041-97a7-ff41-0d8b" type="selectionEntry" targetId="1e9c-6b93-a335-43c4" sortIndex="101">
       <categoryLinks>
         <categoryLink targetId="fe7f-1287-4162-a65d" id="601c-aa25-c822-448a" primary="true" name="Rewards of Treachery"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="2c12-83ba-6a93-f08f" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Inner Circle Knights Cenobium" hidden="false" id="e233-b1f5-c3d1-d731" type="selectionEntry" targetId="e033-118d-4b07-5cd1" sortIndex="103">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="4186-996b-3a05-fe85" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="34ce-cfbd-235d-69b9" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Dreadwing Interemptor Squad" hidden="false" id="ff8c-a2a6-c317-74ca" type="selectionEntry" targetId="d788-b46c-c9f2-0aa9" sortIndex="102">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="a0b8-66e0-e0d8-d844" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="e560-6bf2-3495-d6dd" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Alpharius" hidden="false" id="50a4-4e13-d1e0-3724" type="selectionEntry" targetId="7b1d-a83b-ffc8-aad4" sortIndex="1">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="0c05-ca42-bfef-b3d5" primary="true" name="Warlord"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="49f9-60aa-68ba-8666" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Armillus Dynat" hidden="false" id="5d9b-0cf2-5004-6661" type="selectionEntry" targetId="df2e-ee83-e5e5-c333" sortIndex="2">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="f8f6-5052-e272-aedb" primary="true" name="High Command"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="c0aa-027b-ef90-573d" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Headhunter Kill Team" hidden="false" id="d9c4-2b4e-b466-6a6c" type="selectionEntry" targetId="db52-3de0-a5cf-d943" sortIndex="4">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="8fb9-3ca1-8cfd-7340" primary="true" name="Elites"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="0395-f71e-aae7-3e7b" primary="false" name="Alpha Legion"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set-primary" value="5c0d-4d49-44e2-0a99" field="category">
@@ -1523,221 +1290,265 @@ A Model with this Special Rule is always considered to be 2&quot; further away t
     <entryLink import="true" name="Exodus" hidden="false" id="652f-4031-cc31-ed0b" type="selectionEntry" targetId="9258-8867-220d-429f" sortIndex="5">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="b616-0939-c10f-36d1" primary="true" name="Elites"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="7762-e4a6-d4ee-dc15" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Lernaean Terminator Squad" hidden="false" id="1956-ecc4-3d33-e1c5" type="selectionEntry" targetId="e730-6b3b-7f60-fea0" sortIndex="6">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="c830-926d-4233-727e" primary="true" name="Elites"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="87b6-722b-7f61-2a70" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Saboteur" hidden="false" id="06bd-4447-53c1-638d" type="selectionEntry" targetId="66a2-0979-688a-b47e" sortIndex="3">
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="ce2d-ac84-1c4e-8ca1" primary="true" name="Command"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="b149-957e-1ae2-e871" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Golden Keshing" hidden="false" id="f09a-29ea-bb35-73dd" type="selectionEntry" targetId="fa6f-2652-34c9-2ea2" sortIndex="501">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="065d-43ba-d874-f748" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="1bbb-9e0b-1f2d-b07a" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Ebon Keshig" hidden="false" id="17e8-f624-7de6-b661" type="selectionEntry" targetId="9f57-6829-5ec9-4d69" sortIndex="502">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="a935-60b5-333f-9330" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="2185-ed82-f734-0045" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Kyzagan Assault Speeder" hidden="false" id="d5c4-bc44-b8bc-bd79" type="selectionEntry" targetId="6efd-34c7-2212-1474" sortIndex="503">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="1db2-94ab-0c4e-51b3" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="cf1b-6af0-3e3c-5f58" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Varagyr Wolf Guard Terminators" hidden="false" id="5619-ddc7-4d6a-bbf5" type="selectionEntry" targetId="efd1-c611-841f-0cbb" sortIndex="601">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="438a-693b-8713-33d4" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="37cf-c317-04d9-281e" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Deathsworn Pack" hidden="false" id="9b5e-42f5-8dc1-ac8b" type="selectionEntry" targetId="cb82-a73f-b30f-c30f" sortIndex="602">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="ddc5-a274-df29-cc45" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="9e5d-066f-f703-8a1a" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Grey Slayer Pack" hidden="false" id="9395-0d2e-97d9-3850" type="selectionEntry" targetId="9a43-13b5-bd92-d8be" sortIndex="603">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="f97e-5588-454e-e0dd" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="a10e-c7bb-de2b-138d" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Templar Brethren" hidden="false" id="35d2-7047-d5fd-e80b" type="selectionEntry" targetId="0096-62da-55d8-3912" sortIndex="701">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="b43b-1d11-4ecd-d073" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="531e-6ec1-e52f-e76b" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Phalanx Warder-Squad" hidden="false" id="ed19-fda2-2fc9-bee4" type="selectionEntry" targetId="7ee4-7278-0ad7-4c29" sortIndex="702">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="dc17-6c87-20ee-0652" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="862a-2654-93ac-9915" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Gorgon Terminator Squad" hidden="false" id="579c-48b2-5412-1eb8" type="selectionEntry" targetId="6545-a621-619e-4757" sortIndex="1001">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="d7ab-c5fe-f0b3-8209" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="2f70-5caf-260f-7854" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Medusan Immortals Squad" hidden="false" id="7155-c97e-d6bc-7193" type="selectionEntry" targetId="c54a-6c98-0f74-d45c" sortIndex="1002">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="7f20-93ea-6efc-2f2e" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="4c05-c6fc-0d26-005a" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Invictus Suzerain Squad" hidden="false" id="57ab-0246-a6de-f8c5" type="selectionEntry" targetId="3a11-d72b-2f04-cc62" sortIndex="1301">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="0a7e-0241-6232-cc5b" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="3a1b-66a7-451a-9a8e" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Praetorian Breacher Squad" hidden="false" id="2cef-e544-d639-17cf" type="selectionEntry" targetId="f115-4466-aa86-b446" sortIndex="1302">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="12a0-5f72-93e7-a0fa" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="f5aa-c6af-354e-d77e" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Mor Deythan Squad" hidden="false" id="32d1-d3a5-652b-c679" type="selectionEntry" targetId="4bb8-d53e-23a8-64da" sortIndex="1901">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="7ed8-3862-ae09-5ea6" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="f128-b5ba-f6d3-5868" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Dark Fury Squad" hidden="false" id="53e3-556b-3428-f7a6" type="selectionEntry" targetId="8487-ac3b-d0ec-6d08" sortIndex="1902">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="d19e-492f-ef05-4c28" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="4435-dc26-18f7-37e2" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Phoenix Terminator Squad" hidden="false" id="3075-d904-8fd0-37ef" type="selectionEntry" targetId="e547-ac83-3328-4d31" sortIndex="301">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="08e2-05df-0667-c572" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="bf08-19c9-ed6c-7606" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Palatine Blade Squad" hidden="false" id="1ad2-65c6-b020-2f6a" type="selectionEntry" targetId="8f1b-e5a5-5607-612c" sortIndex="302">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="ff33-1731-a2e9-6082" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="c851-778b-84b9-14e2" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Kakophoni Squad" hidden="false" id="5ef8-1afe-21bc-c2b3" type="selectionEntry" targetId="4ac4-b32a-6840-a91e" sortIndex="303">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="69f0-2238-42d8-27f1" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="d98a-5a69-a22c-aafd" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Tyrant Siege Terminator Squad" hidden="false" id="8f89-8483-d1bc-797f" type="selectionEntry" targetId="83b4-239a-806b-33e5" sortIndex="401">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="bb97-6301-e809-b167" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="0029-a6ce-32ed-fd2e" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Iron Circle Maniple" hidden="false" id="69b6-f54e-63ec-7ad4" type="selectionEntry" targetId="a0e7-1d1c-2d3e-d46d" sortIndex="402">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="8a0e-aca1-c693-a9d2" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="b896-107c-a9a5-0d56" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Contekar Terminator Squad" hidden="false" id="d51d-e5bd-6aca-694f" type="selectionEntry" targetId="baca-aa73-5db0-17fa" sortIndex="801">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="e881-7066-1f98-b2f0" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="2005-0719-cf72-01c2" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Terror Squad" hidden="false" id="2050-ee8a-6308-396e" type="selectionEntry" targetId="d1bc-17f7-b3d7-ca84" sortIndex="802">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="c416-36e4-3093-9391" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="73fd-0ce2-1e04-3280" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Night Raptor Squad" hidden="false" id="43ad-5da3-5b44-c2e0" type="selectionEntry" targetId="2090-3883-5cff-e344" sortIndex="803">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="02ef-426e-387c-695b" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="1d92-dd0f-1129-95ad" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Red Butchers" hidden="false" id="a303-bc62-8d6a-1f11" type="selectionEntry" targetId="e149-7a3c-d62c-e941" sortIndex="1201">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="e749-2396-eff4-0319" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="da2b-3f16-aa12-cefd" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Rampager Squad" hidden="false" id="eb40-7916-1b27-b491" type="selectionEntry" targetId="c660-c7ad-70b0-5318" sortIndex="1202">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="ce71-1a59-3a8a-b62b" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="a0cc-7dc3-ae90-c4be" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Deathshroud Terminator Squad" hidden="false" id="f369-60ca-b8da-d276" type="selectionEntry" targetId="11a2-0875-ae7a-3da2" sortIndex="1401">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="03d0-06eb-2ada-7a95" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="e4b6-5c39-d472-94c2" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Grave Warden Terminator Squad" hidden="false" id="ab50-1a71-93d6-a253" type="selectionEntry" targetId="adff-529b-2bd1-c87f" sortIndex="1402">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="2e99-b418-ac43-9917" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="f7f0-80a5-0998-8e2c" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Sekhmet Terminator Cabal" hidden="false" id="51bc-9508-f427-061d" type="selectionEntry" targetId="c5a4-8dfe-5b4c-eef2" sortIndex="1501">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="5783-1f29-cf57-5638" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="87f2-346c-e890-2605" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Khenetai Occult Cabal" hidden="false" id="fb59-6262-344d-53e1" type="selectionEntry" targetId="3f0f-9a7b-bd90-8fd3" sortIndex="1502">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="d578-cca3-1f8c-c9b6" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="0a29-7aa7-8249-4483" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Castellax-Achea Automata" hidden="false" id="ea92-2ed1-da76-a859" type="selectionEntry" targetId="8372-11b0-af24-4996" sortIndex="1503">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="a6e5-827f-c451-5709" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="e805-5096-868b-d243" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Contemptor-Osiron Dreadnought" hidden="false" id="772e-93f6-cd9c-4bd3" type="selectionEntry" targetId="6580-3281-36a9-564a" sortIndex="1504">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="57e8-ebdc-a2ee-172f" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="124b-2c4a-f5eb-9cae" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Justaerin Terminator Squad" hidden="false" id="83b4-37a3-ea86-daf8" type="selectionEntry" targetId="3866-f18c-3b7c-3a7e" sortIndex="1601">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="d6fa-a6f7-8956-703f" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="672f-dd9e-9cae-1f93" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Reaver Attack Squad" hidden="false" id="2d7d-7084-a3f3-4755" type="selectionEntry" targetId="8010-21cf-b606-b491" sortIndex="1602">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="238c-d52c-48eb-dcd3" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="8fef-a104-8aaa-3046" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Gal Vorbak" hidden="false" id="29d7-1057-a404-365b" type="selectionEntry" targetId="bb3e-f926-23ec-c561" sortIndex="1701">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="fec8-2d8e-bfd8-8575" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="9091-912a-6576-45e9" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Mhara Gal Dreadnought" hidden="false" id="f6e6-9088-e03f-0cae" type="selectionEntry" targetId="87ac-c2df-6bd9-33e3" sortIndex="1702">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="1fe0-5adc-3022-0964" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="17b9-0799-f369-3471" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Ashen Circle" hidden="false" id="bd0f-bbe3-c21b-3d0f" type="selectionEntry" targetId="9290-f8f4-ff78-b09c" sortIndex="1703">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="9f32-c515-7c26-c947" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="e7b7-e63e-041e-212b" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Crimson Paladins" hidden="false" id="1d0d-5979-6e89-ba31" type="selectionEntry" targetId="80bb-caf1-d1fc-0e26" sortIndex="901">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="12d3-178d-7003-37d5" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="2fac-dd27-a8e7-6b64" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Dawnbreaker Cohort" hidden="false" id="d8a0-bc62-310b-9408" type="selectionEntry" targetId="410b-50c3-4f12-1c67" sortIndex="902">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="2867-abb2-ac7e-6b93" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="6794-d532-afc0-b0e9" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="The Angel&apos;s Tears" hidden="false" id="a631-3a91-3dbb-0831" type="selectionEntry" targetId="06d5-d1b3-de1f-7564" sortIndex="903">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="fd79-b34b-96f4-f4d8" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="f844-9032-2241-d851" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Contemptor-Incaendius Dreadnought" hidden="false" id="e204-8dc5-6b36-3bcf" type="selectionEntry" targetId="83ae-08c8-bdf1-ccaa" sortIndex="904">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="2e12-fbea-64a3-6a5e" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="956f-b0be-d33a-6c13" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Firedrake Terminator Squad" hidden="false" id="257b-902d-9037-7245" type="selectionEntry" targetId="09a9-6c68-9b0b-f24f" sortIndex="1801">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="d653-05c8-afeb-cc9b" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="3f04-029d-cfb0-8233" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Pyroclast Squad" hidden="false" id="fe5d-55bb-40fb-3bfe" type="selectionEntry" targetId="fbbe-aa8c-d645-7970" sortIndex="1802">
       <categoryLinks>
         <categoryLink name="Rewards of Treachery" hidden="false" id="3ba7-d01f-f429-7545" targetId="fe7f-1287-4162-a65d" primary="true"/>
+        <categoryLink targetId="a114-fe5b-0a4f-632e" id="e96c-cbf5-b7f9-afe1" primary="false" name="Alpha Legion"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/Blood Angels.cat
+++ b/Blood Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="9cff-ac34-56ca-260f" name="                        IX - Blood Angels" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="LeonisAstra" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="9cff-ac34-56ca-260f" name="                        IX - Blood Angels" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="LeonisAstra" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Legiones Astartes" id="7792-8e57-011d-878e" targetId="9b32-f350-6aa9-9c09" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Wargear" id="560b-6db1-e61d-83a8" targetId="fcc7-4319-bb04-2c25"/>
@@ -37,13 +37,6 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8baf-1c4f-b572-90cd" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3bc2-aaaf-aaf7-b0e2" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink targetId="7799-e1d6-762b-700b" id="6911-6908-a249-b9a5" primary="true" name="Paragon Model Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="1137-4a26-b842-375a" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="d5df-b9c4-7a5d-829e" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="53b2-d251-a827-8e73" id="897c-0689-10fd-3371" primary="false" name="Blood Angels"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="7bf7-01a4-3eb9-b584" primary="false" name="Loyalist"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Infernus" hidden="false" id="fa11-00f8-214a-e46e" sortIndex="1">
               <profiles>
@@ -222,10 +215,11 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="22ee-7208-4089-b005" id="c2f4-87cd-a563-6e44" primary="true" name="Warlord"/>
-        <categoryLink targetId="53b2-d251-a827-8e73" id="621e-016b-2ba9-95c7" primary="false" name="Blood Angels"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="0f59-a5a6-e6fd-148e" primary="false" name="Loyalist"/>
         <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="aa48-cab5-e47f-63c4" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="4d7f-f657-2ef1-5d84" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="e708-5bfa-cbde-b0ca" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="a362-afa8-251d-779d" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="Deep Strike" id="0519-115a-719e-46cb" hidden="false" type="rule" targetId="0553-d06b-52b9-34db"/>
@@ -340,13 +334,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
             <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
             <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
           </costs>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="ee33-c5ad-019a-5620" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="2aeb-b26a-8a65-99f5" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="c81f-eb80-64ee-0442" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="bc2c-eaa1-03fa-fcb1" primary="false" name="Loyalist"/>
-            <categoryLink targetId="53b2-d251-a827-8e73" id="a2b0-9d92-cb02-9235" primary="false" name="Blood Angels"/>
-          </categoryLinks>
           <rules>
             <rule name="Archein of Wisdom" id="66dc-7a58-a98a-bff3" hidden="false">
               <description>While a Model with this Special Rule is Engaged in a Challenge, its Controlling Player can select the &quot;Archein of Wisdom&quot; Gambit.</description>
@@ -359,10 +346,11 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="1e15-25cb-23c4-5347" primary="true" name="High Command"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="2a8c-d415-8022-b569" primary="false" name="Loyalist"/>
-        <categoryLink targetId="53b2-d251-a827-8e73" id="abdd-f62c-01df-983c" primary="false" name="Blood Angels"/>
         <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="db27-ebb1-dc58-606b" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="f993-802a-2ff0-d550" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="3a7d-a7ba-5646-a454" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="da55-f739-3ce1-22f4" primary="false" name="Command Model Sub-type"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -494,14 +482,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
               </constraints>
             </entryLink>
           </entryLinks>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="8ce8-ce52-c53f-a792" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="1e75-e1ea-c0ba-27cb" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="46a8-5a04-3f3f-0adc" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="e0c9-7285-3fed-6df3" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="53b2-d251-a827-8e73" id="66cb-2273-38b9-64c5" primary="false" name="Blood Angels"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="247e-67c1-e0a7-cd81" primary="false" name="Loyalist"/>
-          </categoryLinks>
           <infoLinks>
             <infoLink name="Bulky (X)" id="d03c-815d-cc40-f17b" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
               <modifiers>
@@ -533,10 +513,12 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <infoLink name="Deep Strike" id="08d7-064e-182e-5b42" hidden="false" type="rule" targetId="0553-d06b-52b9-34db"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="eb62-d7c0-fa3f-daff" primary="true" name="Command"/>
         <categoryLink targetId="901a-6b71-7a29-4597" id="c9cd-1e95-4c10-84fa" primary="false" name="Officer of the Line (2)"/>
-        <categoryLink targetId="53b2-d251-a827-8e73" id="6d58-c031-7dcd-149a" primary="false" name="Blood Angels"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="b0f2-3d52-4663-df74" primary="false" name="Loyalist"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="e770-80ea-9ae1-0fdc" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="0f85-583a-b649-276c" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="7971-bc88-a722-767c" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="38d8-8835-f9cd-747c" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
       <constraints>
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="0b8f-5671-24bf-f09b" includeChildSelections="true"/>
@@ -662,13 +644,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
 The first time in any battle that a Model with this Special Rule is reduced to 0 Wounds, before Removing this Model as a Casualty, the Controlling Player must roll a Dice. On a result of a 4+, that Model is not Removed as a Casualty and has its Current Wounds Characteristic Set to 1.</description>
             </rule>
           </rules>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="d29e-ff58-ec0d-d4d3" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="2b78-928e-31df-b998" primary="false" name="Loyalist"/>
-            <categoryLink targetId="53b2-d251-a827-8e73" id="76a2-a273-c615-6b13" primary="false" name="Blood Angels"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="a83f-7b2c-5539-a1e5" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="2125-86dc-20e8-d36d" primary="false" name="Command Model Sub-type"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <constraints>
@@ -686,10 +661,11 @@ The first time in any battle that a Model with this Special Rule is reduced to 0
         </modifier>
       </modifiers>
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="1862-b04b-451a-a0e5" primary="true" name="Command"/>
         <categoryLink targetId="901a-6b71-7a29-4597" id="6396-ad2e-2b92-7bea" primary="false" name="Officer of the Line (2)"/>
-        <categoryLink targetId="53b2-d251-a827-8e73" id="8b22-2880-08bd-d764" primary="false" name="Blood Angels"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="0696-8e23-a7e7-c473" primary="false" name="Loyalist"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="c901-122d-fd8b-9b02" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="43f5-731d-eb8c-ff4d" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="25fb-24dd-baf8-2e16" primary="false" name="Command Model Sub-type"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="155"/>
@@ -793,9 +769,6 @@ The first time in any battle that a Model with this Special Rule is reduced to 0
               </selectionEntries>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <categoryLinks>
-            <categoryLink targetId="38d4-d720-8009-acd3" id="a892-8f25-5824-80bd" primary="true" name="Walker Model Type"/>
-          </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3a1a-2781-9125-74f2" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="78a7-4bd4-db91-7ac4" includeChildSelections="false"/>
@@ -852,7 +825,7 @@ The first time in any battle that a Model with this Special Rule is reduced to 0
         <infoLink name="Deep Strike" id="b849-6212-c699-1950" hidden="false" type="rule" targetId="0553-d06b-52b9-34db"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink targetId="2499-7239-685f-8465" id="a381-4a76-6fe9-a9a0" primary="true" name="War-engine"/>
+        <categoryLink targetId="38d4-d720-8009-acd3" id="e0d5-8967-e606-2837" primary="false" name="Walker Model Type"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="200"/>
@@ -900,8 +873,6 @@ The first time in any battle that a Model with this Special Rule is reduced to 0
           </infoLinks>
           <categoryLinks>
             <categoryLink targetId="647c-faca-3c98-c203" id="006d-ff3b-1358-cd80" primary="false" name="Free Power Weapon"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="0694-9be1-eeea-24fb" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="1f2a-7e45-b1ce-87e2" primary="false" name="Heavy Model Sub-Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="8b0a-47f8-5bb0-f803" primary="false" name="Sergeant Model Sub-Type"/>
           </categoryLinks>
           <selectionEntryGroups>
@@ -1087,7 +1058,8 @@ The first time in any battle that a Model with this Special Rule is reduced to 0
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink targetId="5d5e-958f-e388-50b5" id="93f5-bc9c-a771-1a2f" primary="true" name="Elites"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="554c-f3bd-6e95-6ea0" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="f13c-e673-9834-bfe9" primary="false" name="Heavy Model Sub-Type"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="65"/>
@@ -1143,9 +1115,7 @@ The first time in any battle that a Model with this Special Rule is reduced to 0
           </selectionEntryGroups>
           <categoryLinks>
             <categoryLink targetId="647c-faca-3c98-c203" id="c2df-7d81-b9fa-a6c1" primary="false" name="Free Power Weapon"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="cc3d-e160-30ab-dcf6" primary="true" name="Infantry Model Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="2d8b-de27-e257-c6fa" primary="false" name="Sergeant Model Sub-Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="2867-4e2a-9eab-908c" primary="false" name="Antigrav Model Sub-Type"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2bcb-2361-4e97-776d" includeChildSelections="false"/>
@@ -1221,10 +1191,6 @@ The first time in any battle that a Model with this Special Rule is reduced to 0
             <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
             <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
           </costs>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="5c11-2e82-0023-7fbc" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="27db-fa7e-42e5-18a5" primary="false" name="Antigrav Model Sub-Type"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -1260,7 +1226,8 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
         </selectionEntryGroup>
       </selectionEntryGroups>
       <categoryLinks>
-        <categoryLink targetId="5d5e-958f-e388-50b5" id="9a93-6c57-4b57-4a10" primary="true" name="Elites"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="2c71-eca0-899b-860a" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="118b-5da7-d114-e26f" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="The Angel&apos;s Tears" hidden="false" id="06d5-d1b3-de1f-7564" sortIndex="8">
@@ -1339,10 +1306,6 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
             </entryLink>
             <entryLink import="true" name="Krak grenades" hidden="false" id="6c9b-1a53-dfd7-0b74" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4"/>
           </entryLinks>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="b177-94c0-07bf-511f" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="114f-4578-02be-9640" primary="false" name="Antigrav Model Sub-Type"/>
-          </categoryLinks>
           <costs>
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
@@ -1433,8 +1396,6 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="40d4-b257-dedf-9350" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="26c1-8097-6fb6-3281" primary="false" name="Antigrav Model Sub-Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="664b-cd00-9b63-d9c2" primary="false" name="Sergeant Model Sub-Type"/>
           </categoryLinks>
           <infoLinks>
@@ -1459,7 +1420,8 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
         </infoLink>
       </infoLinks>
       <categoryLinks>
-        <categoryLink targetId="3235-bd79-e9b1-60fa" id="0d4b-d91e-e4f7-2dfc" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="3f61-b9e3-2332-e309" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="b89a-7315-25da-dfa7" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="70"/>
@@ -1587,9 +1549,7 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
     <entryLink import="true" name="Sanguinius" hidden="false" id="a7b0-582a-5cb2-ff69" type="selectionEntry" targetId="0fb0-cab6-34dc-b9b0" sortIndex="1">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="775e-64ed-2816-7692" primary="true" name="Warlord"/>
-        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="a2d5-7aff-bdb0-1741" primary="false" name="Master of the Legion"/>
         <categoryLink targetId="53b2-d251-a827-8e73" id="1ac1-5daa-40db-214d" primary="false" name="Blood Angels"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="761e-7e03-a364-ef04" primary="false" name="Loyalist"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="New Entry" hidden="false" id="d036-bbb6-8fbc-f6ab"/>
@@ -1599,22 +1559,16 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="dc2a-cef1-dc52-f4a8" primary="true" name="High Command"/>
         <categoryLink targetId="53b2-d251-a827-8e73" id="20c7-5922-7818-0dca" primary="false" name="Blood Angels"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="2ec1-1dd7-9cf5-a30e" primary="false" name="Loyalist"/>
-        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="7db0-c553-33f7-0b76" primary="false" name="Master of the Legion"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Dominion Zephon" hidden="false" id="4587-5ecf-2497-4c1b" type="selectionEntry" targetId="07c2-3eb9-2ffe-e900" sortIndex="3">
       <categoryLinks>
-        <categoryLink targetId="901a-6b71-7a29-4597" id="0ed0-a5a3-7475-1e9c" primary="false" name="Officer of the Line (2)"/>
         <categoryLink targetId="53b2-d251-a827-8e73" id="130b-47b4-f10f-d616" primary="false" name="Blood Angels"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="d00f-ded1-485d-a76b" primary="false" name="Loyalist"/>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="a751-e988-0467-70e4" primary="true" name="Command"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Aster Chrone" hidden="false" id="c822-0582-5290-a9d2" type="selectionEntry" targetId="93c6-02e1-f5e2-5b76" sortIndex="4">
       <categoryLinks>
-        <categoryLink targetId="901a-6b71-7a29-4597" id="1693-5d23-fb98-e3fc" primary="false" name="Officer of the Line (2)"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="0d86-c54e-1ba1-e6c0" primary="false" name="Loyalist"/>
         <categoryLink targetId="53b2-d251-a827-8e73" id="e289-5f20-1210-a5ab" primary="false" name="Blood Angels"/>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="ea27-c370-1ecd-aa38" primary="true" name="Command"/>
       </categoryLinks>
@@ -1622,16 +1576,19 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
     <entryLink import="true" name="Contemptor-Incaendius Dreadnought" hidden="false" id="5dc8-3fde-9013-ef36" type="selectionEntry" targetId="83ae-08c8-bdf1-ccaa" sortIndex="5">
       <categoryLinks>
         <categoryLink targetId="2499-7239-685f-8465" id="ca20-6c57-c851-b03b" primary="true" name="War-engine"/>
+        <categoryLink targetId="53b2-d251-a827-8e73" id="e1d6-5c70-cfcc-063e" primary="false" name="Blood Angels"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Crimson Paladins" hidden="false" id="9c1f-d2e5-ac81-f215" type="selectionEntry" targetId="80bb-caf1-d1fc-0e26" sortIndex="6">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="5e09-e90b-ff06-7381" primary="true" name="Elites"/>
+        <categoryLink targetId="53b2-d251-a827-8e73" id="c059-2457-4b93-c16f" primary="false" name="Blood Angels"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Dawnbreaker Cohort" hidden="false" id="3f7e-4c81-2320-a8e5" type="selectionEntry" targetId="410b-50c3-4f12-1c67" sortIndex="7">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="88b3-1cfc-f972-4e85" primary="true" name="Elites"/>
+        <categoryLink targetId="53b2-d251-a827-8e73" id="18d2-b0a4-4d5e-e47b" primary="false" name="Blood Angels"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set-primary" value="97b0-7a9b-b549-18b4" field="category">
@@ -1641,7 +1598,12 @@ When a Unit with at least one Model with this Special Rule is deployed via Deep 
         </modifier>
       </modifiers>
     </entryLink>
-    <entryLink import="true" name="The Angel&apos;s Tears" hidden="false" id="edbe-4d87-ab3d-6f1b" type="selectionEntry" targetId="06d5-d1b3-de1f-7564" sortIndex="8"/>
+    <entryLink import="true" name="The Angel&apos;s Tears" hidden="false" id="edbe-4d87-ab3d-6f1b" type="selectionEntry" targetId="06d5-d1b3-de1f-7564" sortIndex="8">
+      <categoryLinks>
+        <categoryLink targetId="3235-bd79-e9b1-60fa" id="c726-8919-df63-0e9e" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="53b2-d251-a827-8e73" id="7a3e-0062-f3c9-26fe" primary="false" name="Blood Angels"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedRules>
     <rule name="Encarmine Fury" id="2acc-e20b-bef4-a9cc" hidden="false">

--- a/Dark Angels.cat
+++ b/Dark Angels.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="0a35-fce3-188c-b3aa" name="                         I - Dark Angels" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="0a35-fce3-188c-b3aa" name="                         I - Dark Angels" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Assets" id="a476-c36f-b43d-3fd8" targetId="5334-5605-242c-d75e" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Special Rules" id="9620-2bdb-4589-56f8" targetId="106b-693b-99f2-00c3"/>
@@ -40,6 +40,7 @@
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7494-af6a-f401-ea78" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="5866-873e-b02c-9d4f" type="selectionEntry" targetId="31c4-c9d1-fdba-4b21"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="The Blade" hidden="false" id="cb76-bb4b-7531-63f4">
@@ -115,6 +116,13 @@
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="d657-8e1f-0ee5-31af" includeChildSelections="true"/>
       </constraints>
       <comment>High Command</comment>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="fa27-2192-bcbd-f7ab" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="945f-1a7d-3c4c-d993" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="6ae3-f881-b19d-b231" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="f5ae-857b-13e5-1986" primary="false" name="Loyalist"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="2369-5f1b-e0e3-a779" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="false" name="Deathwing Companion Detachment" hidden="false" id="1e9c-6b93-a335-43c4">
       <selectionEntries>
@@ -379,6 +387,9 @@
         <entryLink import="true" name="Prime Unit" hidden="false" id="8d8e-94ec-f857-c8b1" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2"/>
       </entryLinks>
       <comment>Retinue</comment>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="5562-be08-5927-bacd" primary="false" name="Infantry Model Type"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Dreadwing Interemptor Squad" hidden="false" id="d788-b46c-c9f2-0aa9" publicationId="b905-0414-1057-bb34">
       <costs>
@@ -546,6 +557,9 @@
         <infoLink name="The Angels of Death" id="5f90-3677-32b9-2e1c" hidden="false" type="rule" targetId="7fd2-c16b-0e15-9de7"/>
       </infoLinks>
       <comment>Support</comment>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="0ae5-d891-ba59-8a57" primary="false" name="Infantry Model Type"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Inner Circle Knights Cenobium" hidden="false" id="e033-118d-4b07-5cd1">
       <selectionEntries>
@@ -555,9 +569,6 @@
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
           </costs>
-          <categoryLinks>
-            <categoryLink name="Heavy Model Sub-Type" hidden="false" id="b0e4-130b-2c63-a868" targetId="1e7d-9066-28d2-97a0" primary="false"/>
-          </categoryLinks>
           <profiles>
             <profile name="Order Cenobites" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="f02a-ca40-76e4-8ee3">
               <characteristics>
@@ -590,7 +601,6 @@
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
           </costs>
           <categoryLinks>
-            <categoryLink name="Heavy Model Sub-Type" hidden="false" id="e64c-ae8a-22f1-284e" targetId="1e7d-9066-28d2-97a0" primary="false"/>
             <categoryLink name="Sergeant Model Sub-Type" hidden="false" id="fcf7-fd55-a5cf-c8ff" targetId="8045-89a4-76d4-fcef" primary="false"/>
           </categoryLinks>
           <profiles>
@@ -685,6 +695,10 @@
         <entryLink import="true" name="Prime Unit" hidden="false" id="4edf-74d7-ceb9-d5e2" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2"/>
       </entryLinks>
       <comment>Elite</comment>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="5de8-4f08-68e5-def2" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="00f9-71ef-1025-7f20" primary="false" name="Heavy Model Sub-Type"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Lion El&apos;Johnson" hidden="false" id="2516-2347-2ca5-af1d">
       <selectionEntries>
@@ -882,6 +896,12 @@ The Lion&apos;s Choler: If this Gambit is selected, the Model for which this Gam
         </selectionEntryGroup>
       </selectionEntryGroups>
       <comment>Warlord</comment>
+      <categoryLinks>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="0ba6-de00-a697-f095" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="7009-be9f-2b7d-37ee" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="79bb-bb4f-2998-a8b9" primary="false" name="Loyalist"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="b3ba-213a-3ccd-b6a2" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Marduk Sedras" hidden="false" id="34d0-7b32-5875-8d5a">
       <costs>
@@ -893,6 +913,9 @@ The Lion&apos;s Choler: If this Gambit is selected, the Model for which this Gam
         <categoryLink name="Unique Model Sub-Type" hidden="false" id="eda0-0406-4e9e-5c5d" targetId="b980-187b-2b17-d635" primary="false"/>
         <categoryLink name="Command Model Sub-type" hidden="false" id="ffde-a0ef-dfc5-e571" targetId="9871-cb62-5283-2216" primary="false"/>
         <categoryLink name="Heavy Model Sub-Type" hidden="false" id="f2e3-4d86-3386-ceb9" targetId="1e7d-9066-28d2-97a0" primary="false"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="dfde-1b6c-aafd-d7b2" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="435a-be62-a02b-a397" primary="false" name="Loyalist"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="e838-637f-22b1-40cb" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Phosphex bombs" hidden="false" id="00b1-d389-28be-b163" type="selectionEntry" targetId="5ad2-c3b4-f5eb-5b10">
@@ -907,6 +930,7 @@ The Lion&apos;s Choler: If this Gambit is selected, the Model for which this Gam
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8161-023f-734d-3315" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="c938-a09a-6aaa-a19a" type="selectionEntry" targetId="31c4-c9d1-fdba-4b21"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="The Death of Worlds" hidden="false" id="aaaa-0f3f-1b3e-75bb">
@@ -1293,31 +1317,37 @@ The Lion&apos;s Choler: If this Gambit is selected, the Model for which this Gam
     <entryLink import="true" name="Corswain" hidden="false" id="7c9b-42e2-1c81-3e57" type="selectionEntry" targetId="1d4a-09de-2638-e9e0">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="d8a0-2f2c-1900-223d" primary="true" name="High Command"/>
+        <categoryLink targetId="9776-4805-2e0b-1f0f" id="a887-6642-4173-270c" primary="false" name="Dark Angels"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Lion El&apos;Johnson" hidden="false" id="e463-3f44-a9ae-6386" type="selectionEntry" targetId="2516-2347-2ca5-af1d">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="742a-b916-bad8-9196" primary="true" name="Warlord"/>
+        <categoryLink targetId="9776-4805-2e0b-1f0f" id="9d72-a0a3-65a3-55cd" primary="false" name="Dark Angels"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Marduk Sedras" hidden="false" id="3b39-6a5f-307d-2152" type="selectionEntry" targetId="34d0-7b32-5875-8d5a">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="0264-ee51-0899-1480" primary="true" name="High Command"/>
+        <categoryLink targetId="9776-4805-2e0b-1f0f" id="9e7d-31e8-5961-7a69" primary="false" name="Dark Angels"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Deathwing Companion Detachment" hidden="false" id="9601-52bb-0c27-df5f" type="selectionEntry" targetId="1e9c-6b93-a335-43c4">
       <categoryLinks>
         <categoryLink targetId="a38e-50ff-310f-f19e" id="da42-abcd-9be6-27df" primary="true" name="Retinue"/>
+        <categoryLink targetId="9776-4805-2e0b-1f0f" id="12ce-ce5d-d8c4-1dbb" primary="false" name="Dark Angels"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Inner Circle Knights Cenobium" hidden="false" id="e377-3039-fed2-b525" type="selectionEntry" targetId="e033-118d-4b07-5cd1">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="abc4-6cd2-0e8c-b918" primary="true" name="Elites"/>
+        <categoryLink targetId="9776-4805-2e0b-1f0f" id="9166-1e9a-ea91-e46f" primary="false" name="Dark Angels"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Dreadwing Interemptor Squad" hidden="false" id="fbd4-c7ab-dfef-cc42" type="selectionEntry" targetId="d788-b46c-c9f2-0aa9">
       <categoryLinks>
         <categoryLink targetId="345f-9ba6-9b02-ed5c" id="4b0c-13d2-5917-1b1f" primary="true" name="Support"/>
+        <categoryLink targetId="9776-4805-2e0b-1f0f" id="dc91-6e50-a203-0d23" primary="false" name="Dark Angels"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set-primary" value="d52d-47c6-e17a-9e35" field="category">

--- a/Death Guard.cat
+++ b/Death Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="be98-aa9d-64ef-f62c" name="                        XIV - Death Guard" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="1" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="be98-aa9d-64ef-f62c" name="                        XIV - Death Guard" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="2" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Mortarion" hidden="false" id="1e3b-2a3b-c76d-6f98" sortIndex="1">
       <selectionEntries>
@@ -115,6 +115,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <categoryLink targetId="7799-e1d6-762b-700b" id="5dda-8381-575e-17e9" primary="false" name="Paragon Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="be85-312c-affc-3072" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="5887-575e-32fd-678d" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="b8f3-79cc-d246-5782" primary="false" name="Traitor"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="Bulky (X)" id="72c1-76a0-e18d-55e2" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
@@ -322,6 +323,7 @@ Additionally, once per Battle, while the Model with this Special Rule is engaged
         <categoryLink targetId="1e7d-9066-28d2-97a0" id="9c87-84f1-5ee1-0c9a" primary="false" name="Heavy Model Sub-Type"/>
         <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="6752-1a25-ab46-a275" primary="false" name="Master of the Legion"/>
         <categoryLink targetId="9254-b1e9-98b2-6101" id="75b6-318a-5300-f979" primary="false" name="Psyker"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="61b7-0dcb-6e57-cf3c" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="200"/>
@@ -465,7 +467,7 @@ Additionally, once per Battle, while the Model with this Special Rule is engaged
                     <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="03fb-7ed6-4593-3fe4" includeChildSelections="true"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink import="true" name="Assault Grenade Launcher" hidden="false" id="fa74-989c-1dfd-b717" type="selectionEntry" targetId="1662-bcaf-58de-c84a" sortIndex="1"/>
+                    <entryLink import="true" name="Assault grenade launcher" hidden="false" id="fa74-989c-1dfd-b717" type="selectionEntry" targetId="1662-bcaf-58de-c84a" sortIndex="1"/>
                     <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="9c91-27f6-a055-e2ee" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08" sortIndex="2" flatten="true"/>
                   </entryLinks>
                 </selectionEntryGroup>
@@ -523,8 +525,8 @@ Additionally, once per Battle, while the Model with this Special Rule is engaged
                     <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="d973-a4bb-df1b-829b" includeChildSelections="true"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink import="true" name="Assault Grenade Launcher" hidden="false" id="7e5b-d26f-82ef-775f" type="selectionEntry" targetId="1662-bcaf-58de-c84a" sortIndex="1"/>
-                    <entryLink import="true" name="Heavy Alchem Flamer" hidden="false" id="daa5-633a-1a6f-5600" type="selectionEntry" targetId="b21e-8390-ce83-0b6a" sortIndex="2">
+                    <entryLink import="true" name="Assault grenade launcher" hidden="false" id="7e5b-d26f-82ef-775f" type="selectionEntry" targetId="1662-bcaf-58de-c84a" sortIndex="1"/>
+                    <entryLink import="true" name="Heavy alchem flamer" hidden="false" id="daa5-633a-1a6f-5600" type="selectionEntry" targetId="b21e-8390-ce83-0b6a" sortIndex="2">
                       <constraints>
                         <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="a953-d743-e86f-5d26"/>
                       </constraints>
@@ -721,6 +723,7 @@ Process
     <entryLink import="true" name="Mortarion" hidden="false" id="9043-addf-3b9f-47f5" type="selectionEntry" targetId="1e3b-2a3b-c76d-6f98" sortIndex="1">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="6b63-0d0e-dacc-87ff" primary="true" name="Warlord"/>
+        <categoryLink targetId="2399-482f-47f3-add5" id="7d3a-044d-dac0-5ffd" primary="false" name="Death Guard"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -738,6 +741,7 @@ Process
     <entryLink import="true" name="Calas Typhon" hidden="false" id="e362-6664-464c-55c4" type="selectionEntry" targetId="f182-d709-298f-5154" sortIndex="2">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="1e79-9054-cbd5-8d3c" primary="true" name="High Command"/>
+        <categoryLink targetId="2399-482f-47f3-add5" id="26ba-be23-2230-481b" primary="false" name="Death Guard"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -755,11 +759,13 @@ Process
     <entryLink import="true" name="Deathshroud Terminator Squad" hidden="false" id="676f-c38c-9f8a-99e2" type="selectionEntry" targetId="11a2-0875-ae7a-3da2" sortIndex="3">
       <categoryLinks>
         <categoryLink targetId="a38e-50ff-310f-f19e" id="afa0-d79d-08b6-5830" primary="true" name="Retinue"/>
+        <categoryLink targetId="2399-482f-47f3-add5" id="be35-f95a-3d68-ea1a" primary="false" name="Death Guard"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Grave Warden Terminator Squad" hidden="false" id="15d4-c494-15d8-91ae" type="selectionEntry" targetId="adff-529b-2bd1-c87f" sortIndex="4">
       <categoryLinks>
         <categoryLink targetId="3235-bd79-e9b1-60fa" id="c892-1393-02e4-f6dd" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="2399-482f-47f3-add5" id="90bc-ba3f-d0b5-0774" primary="false" name="Death Guard"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/Emperor's Children.cat
+++ b/Emperor's Children.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="9a22-d01f-ab5c-ec07" name="                         III - Emperor&apos;s Children" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="3" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="9a22-d01f-ab5c-ec07" name="                         III - Emperor&apos;s Children" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Legiones Astartes" id="2589-ec0f-809a-8660" targetId="9b32-f350-6aa9-9c09" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Assets" id="a2a4-0123-e538-6ae9" targetId="5334-5605-242c-d75e" importRootEntries="true"/>
@@ -84,7 +84,10 @@
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink name="Warlord" hidden="false" id="757c-5d2c-372e-454a" targetId="22ee-7208-4089-b005" primary="true"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="5dbc-d409-ecb3-b4b3" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="71ce-7f69-8685-80d0" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="2a0a-4d33-485c-e613" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="9e97-9e8e-d2c8-8673" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="425"/>
@@ -128,13 +131,23 @@
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink name="Warlord" hidden="false" id="7004-b039-27fb-a405" targetId="22ee-7208-4089-b005" primary="true"/>
         <categoryLink name="Required Fulgrim Transformed" hidden="false" id="b5a8-bde1-7cdb-1ec4" targetId="634b-596b-118f-80b6" primary="false"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="0e55-2eea-61dc-4103" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="48c8-1116-0198-964e" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="0f4a-4094-4e9c-e1b5" primary="false" name="Antigrav Model Sub-Type"/>
+        <categoryLink targetId="2de1-ddd6-ebb4-10df" id="bc52-2c63-69b3-0941" primary="false" name="Malefic"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="a097-c16d-2334-9db4" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="5004-2de8-de50-4e30" primary="false" name="Traitor"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Lord Commander Eidolon" hidden="false" id="fee3-dc10-99d3-37aa" page="134" publicationId="e54c-7040-0f35-d85d">
       <categoryLinks>
-        <categoryLink name="High Command" hidden="false" id="9e8d-d1f0-0e9b-0468" targetId="d9a6-9b5f-b18a-4d63" primary="true"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="4d5b-3cd6-7afb-bbbd" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="38d9-6b7a-c7e7-2ea1" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="cee4-4c05-f958-69f3" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="5857-7849-7432-f852" primary="false" name="Antigrav Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="1e98-8ce6-89c1-c33e" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="bbe5-f3e7-2b94-0404" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="215"/>
@@ -149,7 +162,10 @@
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink name="Command" hidden="false" id="da00-c0d0-9204-f125" targetId="6dbf-654a-f06f-2d69" primary="true"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="58ba-e12c-6fe4-7f2c" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="73e1-e880-c145-12c6" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="d4d6-5084-1aa6-983c" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="d614-11f5-edda-0847" primary="false" name="Traitor"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Sonic shriekers" hidden="false" id="0ceb-677a-17a6-9abb" type="selectionEntry" targetId="5ec5-2a18-42d2-2e54">
@@ -169,7 +185,12 @@
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink name="Command" hidden="false" id="a7c9-486c-5c45-3c9e" targetId="6dbf-654a-f06f-2d69" primary="true"/>
+        <categoryLink targetId="901a-6b71-7a29-4597" id="a287-41e8-ef65-6c3b" primary="false" name="Officer of the Line (2)"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="2dcf-ac15-8a82-f05b" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="7f8a-8b58-a3ab-555a" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="0127-5b1d-4edf-fa57" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="7aa7-aa0d-19b4-2149" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="0485-5d16-dc7a-021a" primary="false" name="Loyalist"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Phoenix Terminator Squad" hidden="false" id="e547-ac83-3328-4d31" publicationId="e54c-7040-0f35-d85d" page="137">
@@ -183,6 +204,10 @@
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
           </costs>
+          <categoryLinks>
+            <categoryLink targetId="5a95-e564-96b2-8dc9" id="3610-9e08-49c8-6ba5" primary="false" name="Champion Model Sub-Type"/>
+            <categoryLink targetId="8045-89a4-76d4-fcef" id="08da-460f-6512-c080" primary="false" name="Sergeant Model Sub-Type"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry type="model" import="true" name="Phoenix Terminator" hidden="false" id="98e4-4290-bc76-63b1" sortIndex="2" publicationId="e54c-7040-0f35-d85d" page="137" defaultAmount="4">
           <costs>
@@ -202,7 +227,7 @@
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink name="Retinue" hidden="false" id="4ea4-3a9f-2e06-4f74" targetId="a38e-50ff-310f-f19e" primary="true"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="bd69-86ea-6dff-d398" primary="false" name="Infantry Model Type"/>
       </categoryLinks>
       <entryLinks>
         <entryLink targetId="ab39-af3b-58c2-8d9b" id="5f26-d958-57a4-33ec" type="selectionEntryGroup" name="Surgical Augments (All models in a Traitor unit may be given the same):" hidden="false"/>
@@ -283,6 +308,10 @@
               </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <categoryLinks>
+            <categoryLink targetId="8045-89a4-76d4-fcef" id="7b3c-23c6-3ba8-bdc0" primary="false" name="Sergeant Model Sub-Type"/>
+            <categoryLink targetId="5a95-e564-96b2-8dc9" id="d175-803c-12ba-bca1" primary="false" name="Champion Model Sub-Type"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry type="model" import="true" name="Palatine Warrior" hidden="false" id="34df-3bf1-75f0-8ee0" sortIndex="2" page="138" publicationId="e54c-7040-0f35-d85d" defaultAmount="4">
           <costs>
@@ -305,7 +334,7 @@
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink name="Elites" hidden="false" id="37b2-29a9-07f3-c3af" targetId="5d5e-958f-e388-50b5" primary="true"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="3dfd-53bc-489b-e997" primary="false" name="Infantry Model Type"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Surgical Augments (All models in a Traitor unit may be given the same):" hidden="false" id="c9dc-ebe1-fd50-c5d0" targetId="ab39-af3b-58c2-8d9b" type="selectionEntryGroup"/>
@@ -323,6 +352,9 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4af7-05ff-3afb-2be7-min" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4af7-05ff-3afb-2be7-max" includeChildSelections="false"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink targetId="8045-89a4-76d4-fcef" id="982f-67a9-316b-a728" primary="false" name="Sergeant Model Sub-Type"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry type="model" import="true" name="Chora" hidden="false" id="d66a-a50b-2dc9-756a" sortIndex="2" page="139" publicationId="e54c-7040-0f35-d85d" defaultAmount="4">
           <costs>
@@ -337,7 +369,8 @@
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink name="Support" hidden="false" id="d226-7cc3-313a-628b" targetId="345f-9ba6-9b02-ed5c" primary="true"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="1bcf-c1e2-6ddf-5ca6" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="2c16-4956-ae03-3895" primary="false" name="Traitor"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Sonic shriekers" hidden="false" id="5ec5-2a18-42d2-2e54" publicationId="e54c-7040-0f35-d85d" page="125">
@@ -390,14 +423,54 @@
     </selectionEntry>
   </sharedSelectionEntries>
   <entryLinks>
-    <entryLink import="true" name="Captain Lucius" hidden="false" id="79f7-e68d-59dd-0a4c" targetId="2621-860f-a513-e11e" type="selectionEntry"/>
-    <entryLink import="true" name="Fulgrim" hidden="false" id="0d09-afed-def4-7636" targetId="9ba1-40c2-edd5-8bd7" type="selectionEntry"/>
-    <entryLink import="true" name="Fulgrim Transfigured" hidden="false" id="5ca1-8cac-0ae6-8cc7" targetId="7db2-c826-ebc5-1918" type="selectionEntry"/>
-    <entryLink import="true" name="Kakophoni Squad" hidden="false" id="facc-ac40-1968-b4c4" targetId="4ac4-b32a-6840-a91e" type="selectionEntry"/>
-    <entryLink import="true" name="Lord Commander Eidolon" hidden="false" id="48da-d56e-093f-ba1e" targetId="fee3-dc10-99d3-37aa" type="selectionEntry"/>
-    <entryLink import="true" name="Palatine Blade Squad" hidden="false" id="9c35-909c-10a6-5453" targetId="8f1b-e5a5-5607-612c" type="selectionEntry"/>
-    <entryLink import="true" name="Phoenix Terminator Squad" hidden="false" id="22c5-0e0c-1c32-9a41" targetId="e547-ac83-3328-4d31" type="selectionEntry"/>
-    <entryLink import="true" name="Saul Tarvitz" hidden="false" id="2d9d-d95d-5f43-4d05" targetId="fb9a-2484-6aee-fa59" type="selectionEntry"/>
+    <entryLink import="true" name="Captain Lucius" hidden="false" id="79f7-e68d-59dd-0a4c" targetId="2621-860f-a513-e11e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="6dbf-654a-f06f-2d69" id="aae2-9fed-985f-99e0" primary="true" name="Command"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="b909-bec1-2d26-aeda" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Fulgrim" hidden="false" id="0d09-afed-def4-7636" targetId="9ba1-40c2-edd5-8bd7" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="22ee-7208-4089-b005" id="15d2-f042-f960-94c0" primary="true" name="Warlord"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="d700-d299-564c-1d28" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Fulgrim Transfigured" hidden="false" id="5ca1-8cac-0ae6-8cc7" targetId="7db2-c826-ebc5-1918" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="22ee-7208-4089-b005" id="5cfa-7863-963d-ebf7" primary="true" name="Warlord"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="1366-e5e8-82ac-e352" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Kakophoni Squad" hidden="false" id="facc-ac40-1968-b4c4" targetId="4ac4-b32a-6840-a91e" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="345f-9ba6-9b02-ed5c" id="e32f-3a58-6c43-1d11" primary="true" name="Support"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="d09a-f6f7-afbe-2cbe" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Lord Commander Eidolon" hidden="false" id="48da-d56e-093f-ba1e" targetId="fee3-dc10-99d3-37aa" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="c04c-8128-712c-5474" primary="true" name="High Command"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="3b9a-db9a-116f-98a0" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Palatine Blade Squad" hidden="false" id="9c35-909c-10a6-5453" targetId="8f1b-e5a5-5607-612c" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="5d5e-958f-e388-50b5" id="24df-268b-fc9d-07bd" primary="true" name="Elites"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="0ebf-5c92-7195-555c" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Phoenix Terminator Squad" hidden="false" id="22c5-0e0c-1c32-9a41" targetId="e547-ac83-3328-4d31" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="a38e-50ff-310f-f19e" id="3e37-74d8-c7f9-0673" primary="true" name="Retinue"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="1c63-579f-8842-f4a2" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Saul Tarvitz" hidden="false" id="2d9d-d95d-5f43-4d05" targetId="fb9a-2484-6aee-fa59" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink targetId="6dbf-654a-f06f-2d69" id="1af6-d24d-be79-6f1b" primary="true" name="Command"/>
+        <categoryLink targetId="a364-a983-c2b2-cbc7" id="ed1b-bf9a-4945-7877" primary="false" name="Emperor&apos;s Children"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Surgical Augments" id="bcb8-3151-6aff-5203" hidden="false">

--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -262,6 +262,7 @@
     <categoryEntry name="Heavy Assault - Cataphractii or Tartaros Only" id="6cc6-9558-dd27-949f" hidden="false"/>
     <categoryEntry name="Heavy Assault - Rampager Squads Only" id="91f0-1b91-0a9a-c542" hidden="false"/>
     <categoryEntry name="Elites - Seeker Squads or Headhunter Kill Teams Only" id="5c0d-4d49-44e2-0a99" hidden="false"/>
+    <categoryEntry name="Medusan Vanguard Unlock" id="fc09-911b-ee8c-7967" hidden="true"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry name="Crusade Force Organization Chart" id="8562-592c-8d4b-a1f0" hidden="false" childForcesLabel="Detachments" sortIndex="1">
@@ -4040,7 +4041,7 @@
             </categoryLink>
           </categoryLinks>
           <modifiers>
-            <modifier type="set" value="false" field="hidden">
+            <modifier type="increment" value="1" field="cbbf-a5c7-0527-b306">
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
@@ -4053,8 +4054,22 @@
               </conditionGroups>
               <comment>IW Only</comment>
             </modifier>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="21c0-18db-03dd-ae07" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="21c0-18db-03dd-ae07" shared="true"/>
+                  </conditions>
+                  <comment>IW</comment>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
           </modifiers>
           <comment>IW Only</comment>
+          <constraints>
+            <constraint type="max" value="0" field="forces" scope="roster" shared="true" id="cbbf-a5c7-0527-b306"/>
+          </constraints>
         </forceEntry>
         <forceEntry name="Auxiliary - The Ironfire Cohort" id="5bc5-5224-c751-d437" hidden="true" sortIndex="71">
           <categoryLinks>
@@ -5939,11 +5954,13 @@
           <modifiers>
             <modifier type="increment" value="1" field="06ca-d5c5-58f1-f184">
               <conditionGroups>
-                <conditionGroup type="or">
+                <conditionGroup type="and">
                   <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="6827-05e8-73ff-ead8" shared="true" includeChildSelections="true" includeChildForces="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="0dbe-8971-9089-37e4" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="736e-3967-e72b-e3ac" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="736e-3967-e72b-e3ac" shared="true"/>
+                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="fc09-911b-ee8c-7967" shared="true" includeChildSelections="true" includeChildForces="true"/>
                   </conditions>
+                  <comment>IW</comment>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
@@ -12838,6 +12855,23 @@ Please don&apos;t submit bug reports for any of these things. Please only submit
         <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="98f0-4cab-2f85-12db-min" includeChildSelections="false"/>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="98f0-4cab-2f85-12db-max" includeChildSelections="false"/>
       </constraints>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden">
+          <conditions>
+            <condition type="equalTo" value="1" field="selections" scope="parent" childId="c857-47bd-6a4f-fcf8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="98f0-4cab-2f85-12db-min">
+          <conditions>
+            <condition type="equalTo" value="1" field="selections" scope="parent" childId="c857-47bd-6a4f-fcf8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="0" field="98f0-4cab-2f85-12db-max">
+          <conditions>
+            <condition type="equalTo" value="1" field="selections" scope="parent" childId="c857-47bd-6a4f-fcf8" shared="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Rewards of Treachery" hidden="true" id="7c64-0321-e098-fd0e">
       <rules>

--- a/Imperial Fists.cat
+++ b/Imperial Fists.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="d186-cffc-0950-f632" name="                         VII - Imperial Fists" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="d186-cffc-0950-f632" name="                         VII - Imperial Fists" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="6" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Assets" id="4314-0fbc-731a-fa14" targetId="5334-5605-242c-d75e" importRootEntries="true"/>
     <catalogueLink type="catalogue" name="Legiones Astartes" id="5470-c826-a822-2caa" targetId="9b32-f350-6aa9-9c09" importRootEntries="true"/>
@@ -99,14 +99,6 @@ Additionally, when the Controlling Player issues a Challenge for Sigismund (incl
 Death&apos;s Champion: If this Gambit is selected, attacks made by this Model in the following Strike Step have the Critical Hit (5+) Special Rule.</description>
             </rule>
           </rules>
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="7d90-30ce-61b6-ccd5" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="9ad4-1c74-e915-681a" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="6dbf-654a-f06f-2d69" id="963e-c3ee-952c-a3d4" primary="false" name="Command"/>
-            <categoryLink targetId="450e-112d-a64a-ef6e" id="9d74-cfb6-7722-c97b" primary="false" name="Imperial Fists"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="5b1d-3676-b0f0-affa" primary="false" name="Loyalist"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="c482-8574-f608-dad6" primary="false" name="Master of the Legion"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Bolt pistol" hidden="false" id="75e3-2ef9-0cb7-f294" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="2">
               <constraints>
@@ -141,6 +133,13 @@ Death&apos;s Champion: If this Gambit is selected, attacks made by this Model in
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="fe33-7498-04ae-4253" primary="false" name="Loyalist"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="31c4-dea6-853e-ac78" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="1c51-2b78-676c-1c33" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="4141-b0a6-d0ad-44b8" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="aad4-977f-9258-87f4" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Rogal Dorn" hidden="false" id="7067-3938-a4ea-112c">
       <selectionEntries>
@@ -275,13 +274,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then all Mode
 Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Models in this Army with the Infantry Type and the Imperial Fists Trait have a 5+ Cover Save while they are within their Controlling Player&apos;s Deployment Zone.</description>
             </rule>
           </rules>
-          <categoryLinks>
-            <categoryLink targetId="7799-e1d6-762b-700b" id="4787-2b03-00ea-eb47" primary="false" name="Paragon Model Type"/>
-            <categoryLink targetId="450e-112d-a64a-ef6e" id="7353-620c-e46c-f07c" primary="false" name="Imperial Fists"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="d4c7-d069-a7a2-a167" primary="false" name="Loyalist"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="e906-f27c-b13b-ab9a" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="80d9-d5bf-6137-f61a" primary="false" name="Master of the Legion"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -289,6 +281,12 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="af77-0e80-9f47-f19b" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="c2a1-6267-d95e-374b" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="12f6-f986-31b4-85a4" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="7ad7-0ed4-0dab-e4fc" primary="false" name="Loyalist"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Solarite Power Gauntlet" hidden="false" id="3b91-56eb-e1fc-7567">
       <profiles>
@@ -469,15 +467,6 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
             </infoLink>
             <infoLink name="Fire Discipline" id="6a0c-dce1-64d0-fa88" hidden="false" type="rule" targetId="43fe-8703-9ddf-686c"/>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="badb-7637-2170-e402" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="6002-09f9-7118-5fac" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="403b-d793-2acf-889d" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="f45b-f67e-2d9c-cd41" primary="false" name="Heavy Model Sub-Type"/>
-            <categoryLink targetId="450e-112d-a64a-ef6e" id="5a66-4c00-949b-c8d3" primary="false" name="Imperial Fists"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="540e-c103-c023-e75e" primary="false" name="Loyalist"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="b672-0913-3b7a-daa7" primary="false" name="Master of the Legion"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -492,6 +481,14 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="0454-5d35-5289-aca1" primary="false" name="Loyalist"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="ee53-287d-2ee2-73ad" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="3b5a-5e15-3048-437c" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="85f7-9da3-d4d2-e22b" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="01fe-d3d5-1479-2c77" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="e544-96b6-04bd-7c19" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Phalanx Warder-Squad" hidden="false" id="7ee4-7278-0ad7-4c29">
       <selectionEntries>
@@ -522,10 +519,7 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="9f89-8e34-3e81-88ca" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="8045-89a4-76d4-fcef" id="42c0-b816-df4b-1ed6" primary="false" name="Sergeant Model Sub-Type"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="47fe-f72b-fac3-2592" primary="false" name="Heavy Model Sub-Type"/>
-            <categoryLink targetId="26c6-e05c-0f72-7852" id="4af3-944c-1628-f42b" primary="false" name="Shield"/>
+            <categoryLink targetId="8045-89a4-76d4-fcef" id="27cc-591a-0bc9-36fe" primary="false" name="Sergeant Model Sub-Type"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="The Warder Sergeant may exchanged its power axe for one of the following::" id="68b5-3a82-acaf-57da" hidden="false" defaultSelectionEntryId="7e32-6cec-e103-8d52" sortIndex="1" collapsible="true">
@@ -605,11 +599,6 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="b475-6034-41dc-5293" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="0877-6f4d-9037-1176" primary="false" name="Heavy Model Sub-Type"/>
-            <categoryLink targetId="26c6-e05c-0f72-7852" id="e27f-e42c-0090-641a" primary="false" name="Shield"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="Legion Equipment" id="91ab-fb96-4376-0381" hidden="false" collapsible="true" sortIndex="3">
               <constraints>
@@ -703,6 +692,11 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
         <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
         <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="f8cc-1103-d2aa-26cf" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="e20d-c6de-0862-9329" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="b2b2-9766-65c1-20b2" primary="false" name="Shield"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Camba Diaz" hidden="false" id="0511-25f6-aaef-e1dd">
       <selectionEntries>
@@ -776,14 +770,6 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="160b-e3bd-7767-86f2" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="6e21-70e3-c92b-c34a" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="6dbf-654a-f06f-2d69" id="074b-7597-b0be-3dbd" primary="false" name="Command"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="88c7-a796-874b-ff3f" primary="false" name="Loyalist"/>
-            <categoryLink targetId="450e-112d-a64a-ef6e" id="f7ec-213b-1ea1-b3dc" primary="false" name="Imperial Fists"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="9500-aab4-cfb5-4398" primary="false" name="Master of the Legion"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Frag grenades" hidden="false" id="cf9a-606b-5fd5-ee4e" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="4">
               <constraints>
@@ -818,6 +804,14 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="34a8-a12b-50e4-e090" primary="false" name="Loyalist"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="85aa-0a03-0439-d7aa" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="5cfd-a43a-6860-f92d" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="ca38-ead5-457a-2c32" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="97c5-eda1-5bc0-9ba6" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="901a-6b71-7a29-4597" id="ba6d-5b69-3596-b1ac" primary="false" name="Officer of the Line (2)"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Alexis Polux" hidden="false" id="bb94-88c3-c9b8-c117">
       <selectionEntries>
@@ -891,14 +885,6 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
               <description>If a Model with this Special Rule joins a Breacher Squad Unit in Reserves, Models in that Unit gain the Deep Strike Special Rule while this Model is part of the Unit. In addition, when a Model with this Special Rule is deployed as part of a Deep Strike, that Model and each other Model in the same Unit gain the Feel No Pain (5+) Special Rule until the Controlling Player&apos;s next Effects Sub-Phase.</description>
             </rule>
           </rules>
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="a5c8-8dbd-1bb8-5748" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="f28d-fe2f-ddd0-8959" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="6dbf-654a-f06f-2d69" id="40a9-2c15-8088-2d7a" primary="false" name="Command"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="e7a3-586a-7268-a22b" primary="false" name="Heavy Model Sub-Type"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="2344-b14e-046e-d88f" primary="false" name="Loyalist"/>
-            <categoryLink targetId="450e-112d-a64a-ef6e" id="da58-f92d-8ea4-816e" primary="false" name="Imperial Fists"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Solarite Power Gauntlet" hidden="false" id="303d-f5c6-6517-f7e4" type="selectionEntry" targetId="3b91-56eb-e1fc-7567" sortIndex="1">
               <constraints>
@@ -945,6 +931,15 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="e4f4-b175-fc2f-9189" primary="false" name="Loyalist"/>
+        <categoryLink targetId="901a-6b71-7a29-4597" id="ddf6-3b0c-b6e4-f2da" primary="false" name="Officer of the Line (2)"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="db37-acb2-27bd-a694" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="91bf-eae5-46e0-776d" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="7105-369d-aaa0-2a20" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="0388-9289-bc82-b143" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="8515-1ceb-c7f8-b3e5" primary="false" name="Shield"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Templar Brethren" hidden="false" id="0096-62da-55d8-3912">
       <selectionEntries>
@@ -975,7 +970,6 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="ef3d-2a3d-de1c-bf4f" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="5a95-e564-96b2-8dc9" id="11c8-c6d2-8d9a-d812" primary="false" name="Champion Model Sub-Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="e429-b398-b38a-0e3d" primary="false" name="Sergeant Model Sub-Type"/>
           </categoryLinks>
@@ -1061,9 +1055,6 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="9d1c-fc3f-8e86-a927" primary="false" name="Infantry Model Type"/>
-          </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="A Templar Brethren may exchanged its bolt pistol:" id="b7d3-e1bb-4ad5-6ff7" hidden="false" defaultSelectionEntryId="6627-0742-58b8-785f" sortIndex="2" collapsible="true">
               <entryLinks>
@@ -1168,6 +1159,9 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="0751-fd40-907e-e4c3" primary="false" name="Infantry Model Type"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Fafnir Rann" hidden="false" id="21f3-6129-c7dd-8749">
       <selectionEntries>
@@ -1247,15 +1241,6 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="1345-291e-866b-216c" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="8d1c-8182-644e-29e4" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="db94-d5a4-865c-8c23" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="2048-8788-a41a-3e07" primary="false" name="Heavy Model Sub-Type"/>
-            <categoryLink targetId="450e-112d-a64a-ef6e" id="df3d-c584-c737-7bfc" primary="false" name="Imperial Fists"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="f288-18d1-3f48-07af" primary="false" name="Loyalist"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="6138-cb14-b87b-525c" primary="false" name="Master of the Legion"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Krak grenades" hidden="false" id="51fa-e4e7-fc5a-d50d" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
               <constraints>
@@ -1304,6 +1289,15 @@ The Controlling Player of a Model with this Special Rule does not suffer a penal
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="3270-2706-2e03-54e6" primary="false" name="Loyalist"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="9e4f-c04a-3825-eb31" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="d769-0e41-958e-1f31" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="57d4-fa84-b460-4895" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="2f38-def0-b25f-9eec" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="aa17-c437-0188-2e01" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="bc8e-ddc1-af8a-92c2" primary="false" name="Shield"/>
+      </categoryLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <sharedRules>
@@ -1322,41 +1316,49 @@ The Controlling Player of a Model with this Special Rule does not suffer a penal
     <entryLink import="true" name="Evander Garrius" hidden="false" id="64df-65a8-7276-df76" type="selectionEntry" targetId="6819-8014-fe49-2e96">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="19ba-0605-2f92-b84e" primary="true" name="High Command"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="7996-b441-706e-b54b" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Rogal Dorn" hidden="false" id="2306-2636-3ed8-db90" type="selectionEntry" targetId="7067-3938-a4ea-112c">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="3485-109e-dcea-4a80" primary="true" name="Warlord"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="95f8-519e-9139-08dd" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Sigismund" hidden="false" id="6ced-891d-49c6-d087" type="selectionEntry" targetId="4870-010f-27b4-20db">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="6822-367d-e39d-a141" primary="true" name="High Command"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="ef82-0ea9-11c0-1b4a" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Templar Brethren" hidden="false" id="cca3-792a-0e89-9443" type="selectionEntry" targetId="0096-62da-55d8-3912">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="db4c-5aff-63be-cabc" primary="true" name="Elites"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="e2d3-d72e-e690-7034" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Camba Diaz" hidden="false" id="7242-e10f-2d56-32dc" type="selectionEntry" targetId="0511-25f6-aaef-e1dd">
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="b923-31ea-b8b2-7648" primary="true" name="Command"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="bc42-7a5d-ecb8-4390" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Alexis Polux" hidden="false" id="35e1-315a-450b-2299" type="selectionEntry" targetId="bb94-88c3-c9b8-c117">
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="d670-287a-31d6-0aaa" primary="true" name="Command"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="7cde-df23-e122-dda0" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Phalanx Warder-Squad" hidden="false" id="0f66-b753-ed91-e9b5" type="selectionEntry" targetId="7ee4-7278-0ad7-4c29">
       <categoryLinks>
         <categoryLink targetId="3235-bd79-e9b1-60fa" id="682d-74c0-381e-23af" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="984b-4e51-6322-53e6" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Fafnir Rann" hidden="false" id="e66c-b812-712c-1a8f" type="selectionEntry" targetId="21f3-6129-c7dd-8749">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="a290-4f34-0537-133d" primary="true" name="High Command"/>
+        <categoryLink targetId="450e-112d-a64a-ef6e" id="5a7c-9a22-8b2b-ead1" primary="false" name="Imperial Fists"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/Iron Hands.cat
+++ b/Iron Hands.cat
@@ -186,6 +186,9 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
       <categoryLinks>
         <categoryLink targetId="7799-e1d6-762b-700b" id="a605-db02-1e07-f74e" primary="false" name="Paragon Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="ab9d-3f6b-950a-aaec" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="fc09-911b-ee8c-7967" id="5f84-6bf9-420b-2ff2" primary="false" name="Medusan Vanguard Unlock"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="12a7-d6af-1a32-c299" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="b45a-d13a-c404-ae95" primary="false" name="Loyalist"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Artificer Power Axe" hidden="false" id="68e3-de15-d977-3c36">
@@ -334,6 +337,8 @@ A Model with Armatus Necrotechnika gains teh Auto-Repair (5+) Special Rule. Addi
         <categoryLink targetId="594d-fa82-13cb-a345" id="ee11-9bee-a108-1f6d" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="91f0-99cd-d8f5-660c" primary="false" name="Command Model Sub-type"/>
         <categoryLink targetId="1e7d-9066-28d2-97a0" id="75fc-559c-2f3d-d4c4" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="fc09-911b-ee8c-7967" id="7f3b-787c-0f2a-00e6" primary="false" name="Medusan Vanguard Unlock"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="57d6-8f89-f8ce-9c07" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <rules>
         <rule name="Lord of Automata" id="8e20-4195-d824-af90" hidden="false"/>
@@ -551,6 +556,7 @@ A Model with Armatus Necrotechnika gains teh Auto-Repair (5+) Special Rule. Addi
       <categoryLinks>
         <categoryLink targetId="594d-fa82-13cb-a345" id="49b2-dcd2-5148-de73" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="1e7d-9066-28d2-97a0" id="8142-9b7d-040d-cb48" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="0a83-23d9-7d13-2769" primary="false" name="Shield"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="35"/>
@@ -695,6 +701,8 @@ A Model with Armatus Necrotechnika gains teh Auto-Repair (5+) Special Rule. Addi
         <categoryLink targetId="594d-fa82-13cb-a345" id="4d36-c845-846a-fbb4" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="e4ee-df2c-875f-82e4" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="fbdd-098b-e865-5e47" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="a0b3-5327-cb3d-c6ce" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="d9a4-dc24-9b43-fea8" primary="false" name="Loyalist"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Gorgon Terminator Squad" hidden="false" id="6545-a621-619e-4757">
@@ -858,26 +866,31 @@ A Model with Armatus Necrotechnika gains teh Auto-Repair (5+) Special Rule. Addi
     <entryLink import="true" name="Gorgon Terminator Squad" hidden="false" id="7f58-f601-545f-35d5" type="selectionEntry" targetId="6545-a621-619e-4757">
       <categoryLinks>
         <categoryLink targetId="3235-bd79-e9b1-60fa" id="c1b3-49f6-cb2e-56a8" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="3db6-86ea-fd61-340b" id="d5b7-8143-0124-bb9b" primary="false" name="Iron Hands"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Iron Father" hidden="false" id="6827-05e8-73ff-ead8" type="selectionEntry" targetId="34fa-844e-fbfb-3737">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="a3d0-fc00-5133-8341" primary="true" name="High Command"/>
+        <categoryLink targetId="3db6-86ea-fd61-340b" id="1bc3-3855-d42f-cda3" primary="false" name="Iron Hands"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Medusan Immortals Squad" hidden="false" id="bd09-0375-e876-b754" type="selectionEntry" targetId="c54a-6c98-0f74-d45c">
       <categoryLinks>
         <categoryLink targetId="88e6-d373-4152-0dd8" id="a763-c284-5eec-7633" primary="true" name="Troops"/>
+        <categoryLink targetId="3db6-86ea-fd61-340b" id="d87c-3cd5-dfcd-ea9c" primary="false" name="Iron Hands"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Shadrak Meduson" hidden="false" id="951e-fe53-524b-f379" type="selectionEntry" targetId="218f-d70c-501e-0572">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="715c-2a5c-cb2f-d644" primary="true" name="High Command"/>
+        <categoryLink targetId="3db6-86ea-fd61-340b" id="f3ce-8973-9507-6c26" primary="false" name="Iron Hands"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Ferrus Manus" hidden="false" id="0dbe-8971-9089-37e4" type="selectionEntry" targetId="667d-97c2-e1ea-8fa6">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="333a-0610-d6ac-7106" primary="true" name="Warlord"/>
+        <categoryLink targetId="3db6-86ea-fd61-340b" id="2866-7048-aeed-d31c" primary="false" name="Iron Hands"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Rite of War" hidden="false" id="fe89-4aba-284d-0f89" type="selectionEntry" targetId="6909-3cb7-c511-da4b">

--- a/Iron Warriors.cat
+++ b/Iron Warriors.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="21c0-18db-03dd-ae07" name="                         IV - Iron Warriors" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="1" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="21c0-18db-03dd-ae07" name="                         IV - Iron Warriors" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="2" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Assets" id="93f1-4e60-f6d6-bf11" importRootEntries="true" targetId="5334-5605-242c-d75e"/>
     <catalogueLink type="catalogue" name="Legiones Astartes" id="e254-e9ad-1ae7-e52a" importRootEntries="true" targetId="9b32-f350-6aa9-9c09"/>
@@ -179,6 +179,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <categoryLink targetId="b980-187b-2b17-d635" id="f6d5-6d4d-95b9-d574" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="b7c9-7d2d-fb56-5486" id="5891-40c7-e5b2-3c51" primary="false" name="The Hammer of Olympia Unlock"/>
         <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="d3a5-7e83-41dc-2a27" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="abe6-2dde-c40f-0e4f" primary="false" name="Traitor"/>
       </categoryLinks>
       <profiles>
         <profile name="The Breaker" typeId="9b5f-da4e-5739-cbcf" typeName="Gambit:" hidden="false" id="be3f-8d26-fcae-7561" page="151" publicationId="e54c-7040-0f35-d85d">
@@ -229,8 +230,7 @@ While a Model with this special rule is in a Challenge, its Controlling Player c
     <selectionEntry type="upgrade" import="true" name="Legion Tactica: IW" hidden="false" id="c4ef-5251-66c7-1059" publicationId="e54c-7040-0f35-d85d">
       <rules>
         <rule name="The Bitter End" id="cd26-01e1-0284-9fc9" hidden="false" publicationId="e54c-7040-0f35-d85d" page="148">
-          <description>If the Controlling Player is making a Leadership Check or Cool Check for a Unit that includes a majority of Models with this Special Rule, they may ignore negative modifiers applied by the Panic (X), Pinning (X), Stun (X) or Suppressive (X) Special Rules.
-</description>
+          <description>If the Controlling Player is making a Leadership Check or Cool Check for a Unit that includes a majority of Models with this Special Rule, they may ignore negative modifiers applied by the Panic (X), Pinning (X), Stun (X) or Suppressive (X) Special Rules.</description>
         </rule>
       </rules>
     </selectionEntry>
@@ -380,6 +380,7 @@ While a Model with this special rule is in a Challenge, its Controlling Player c
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b7e8-26c2-e706-a45e"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="69e8-ddbf-ea18-8187" type="selectionEntry" targetId="31c4-c9d1-fdba-4b21"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Tyrant Siege Terminator Squad" hidden="false" id="83b4-239a-806b-33e5" sortIndex="3">
@@ -743,6 +744,7 @@ Process.
     <entryLink import="true" name="Perturabo" hidden="false" id="06e0-8a81-4a75-4787" type="selectionEntry" targetId="2ff4-482b-a2b2-f853" sortIndex="1">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="69c3-cff4-ac1b-8d54" primary="true" name="Warlord"/>
+        <categoryLink targetId="b5d8-c965-7970-673f" id="bf6f-f048-17d4-6681" primary="false" name="Iron Warriors"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -760,16 +762,19 @@ Process.
     <entryLink import="true" name="Warsmith" hidden="false" id="b201-c904-7a3d-efdc" type="selectionEntry" targetId="5e76-088c-91c5-2d4d" sortIndex="2">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="d10c-750c-d061-b7d6" primary="true" name="High Command"/>
+        <categoryLink targetId="b5d8-c965-7970-673f" id="3ecb-9947-8273-6e64" primary="false" name="Iron Warriors"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Tyrant Siege Terminator Squad" hidden="false" id="8406-59c8-611c-2ff8" type="selectionEntry" targetId="83b4-239a-806b-33e5" sortIndex="3">
       <categoryLinks>
         <categoryLink targetId="3235-bd79-e9b1-60fa" id="498c-288d-9d94-935f" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="b5d8-c965-7970-673f" id="fcc9-a2ab-cecb-ab05" primary="false" name="Iron Warriors"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Iron Circle Maniple" hidden="false" id="23e1-7c35-c3b7-ae24" type="selectionEntry" targetId="a0e7-1d1c-2d3e-d46d" sortIndex="4">
       <categoryLinks>
         <categoryLink targetId="a38e-50ff-310f-f19e" id="9c37-18c3-9583-bdf4" primary="true" name="Retinue"/>
+        <categoryLink targetId="b5d8-c965-7970-673f" id="d4e6-3f81-7f8f-c543" primary="false" name="Iron Warriors"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="16" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="17" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>

--- a/Night Lords.cat
+++ b/Night Lords.cat
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="486f-b32a-ac87-73dd" name="                         VIII - Night Lords" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="6" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="486f-b32a-ac87-73dd" name="                         VIII - Night Lords" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="7" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
-    <selectionEntry type="unit" import="true" name="Konrad Kurze" hidden="false" id="f5fd-f425-c610-4a94">
+    <selectionEntry type="unit" import="true" name="Konrad Curze" hidden="false" id="f5fd-f425-c610-4a94">
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Konrad Kurze" hidden="false" id="e47b-d8f0-a85c-71a9" sortIndex="1">
+        <selectionEntry type="model" import="true" name="Konrad Curze" hidden="false" id="e47b-d8f0-a85c-71a9" sortIndex="1">
           <profiles>
             <profile name="Konrad Kurze" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="a6fc-e95a-426b-2aa8">
               <characteristics>
@@ -140,6 +140,8 @@ When this Gambit is selected, the Controlling Player can make one Willpower Chec
       <categoryLinks>
         <categoryLink targetId="7799-e1d6-762b-700b" id="12e4-2d1d-57a7-4717" primary="false" name="Paragon Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="da6b-ec07-3647-97ab" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="47c4-7941-49b4-fe74" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="6386-75c5-d172-5669" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="450"/>
@@ -976,7 +978,9 @@ When this Gambit is selected, the Controlling Player can make one Willpower Chec
       <categoryLinks>
         <categoryLink targetId="594d-fa82-13cb-a345" id="3515-78f7-214f-b6c6" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="ff93-6618-5e9f-1ef0" primary="false" name="Unique Model Sub-Type"/>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="d8ef-9eb1-7313-dda7" primary="false" name="Command"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="a62d-1bc3-a76f-43aa" primary="false" name="Traitor"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="711d-d965-1843-2387" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="bdc6-e680-52b6-c03a" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Bolt pistol" hidden="false" id="a6ce-dc34-64c1-13cb" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="3">
@@ -1060,16 +1064,19 @@ When this Gambit is selected, the Controlling Player can make one Willpower Chec
     <entryLink import="true" name="Contekar Terminator Squad" hidden="false" id="d84c-210c-2494-136a" type="selectionEntry" targetId="baca-aa73-5db0-17fa">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="7967-1f53-e431-028f" primary="true" name="Elites"/>
+        <categoryLink targetId="9c9d-4e53-09d5-8748" id="34a1-f579-b5e2-d6cc" primary="false" name="Night Lords"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Konrad Kurze" hidden="false" id="15d6-a1f4-4e9c-40c4" type="selectionEntry" targetId="f5fd-f425-c610-4a94">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="9b47-0648-01c7-250d" primary="true" name="Warlord"/>
+        <categoryLink targetId="9c9d-4e53-09d5-8748" id="240f-410b-adc0-0c87" primary="false" name="Night Lords"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Night Raptor Squad" hidden="false" id="d958-12a2-ec35-ac8f" type="selectionEntry" targetId="2090-3883-5cff-e344">
       <categoryLinks>
         <categoryLink targetId="cf96-8891-3f9a-8921" id="8f7f-0978-b6f6-7b7f" primary="true" name="Fast Attack"/>
+        <categoryLink targetId="9c9d-4e53-09d5-8748" id="f724-5479-4e7d-a75d" primary="false" name="Night Lords"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Terror Squad" hidden="false" id="1601-d678-e09f-042a" type="selectionEntry" targetId="d1bc-17f7-b3d7-ca84">
@@ -1082,11 +1089,13 @@ When this Gambit is selected, the Controlling Player can make one Willpower Chec
       </modifiers>
       <categoryLinks>
         <categoryLink targetId="88e6-d373-4152-0dd8" id="3895-612c-b9ba-a74c" primary="true" name="Troops"/>
+        <categoryLink targetId="9c9d-4e53-09d5-8748" id="7abe-8ee5-ed6a-2150" primary="false" name="Night Lords"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Sevatar" hidden="false" id="250f-e956-e1d3-c2c9" type="selectionEntry" targetId="b970-48ad-c8ff-86ca">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="8dda-b541-96f6-06bc" primary="true" name="High Command"/>
+        <categoryLink targetId="9c9d-4e53-09d5-8748" id="f0b2-8856-8b9e-e086" primary="false" name="Night Lords"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Rite of War" hidden="false" id="bcae-e46d-5ae7-82de" type="selectionEntry" targetId="33f3-b1d3-7b30-e5ea">
@@ -1139,9 +1148,7 @@ If selected, at the Start of the Focus Step, this Model&apos;s Controlling Playe
                     <characteristic name="Process" typeId="57cf-1c68-a020-2529">1. Once this Reaction is declared, the Reacting Unit must immediately make a Fall Back Move as if it was affected by the Routed Tactical Status.
 
 
-2. Once this Fall Back Move is completed, the Reacting Unit does not gain the Routed Tactical Status.
-
-</characteristic>
+2. Once this Fall Back Move is completed, the Reacting Unit does not gain the Routed Tactical Status.</characteristic>
                   </characteristics>
                 </profile>
               </profiles>

--- a/Raven Guard.cat
+++ b/Raven Guard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="340c-1d4f-1f31-fb70" name="                       XIX - Raven Guard" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="3" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="340c-1d4f-1f31-fb70" name="                       XIX - Raven Guard" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Corvus Corax" hidden="false" id="e0a6-5800-3e64-4163" sortIndex="1">
       <selectionEntries>
@@ -35,13 +35,6 @@
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9a19-109d-e148-5dfa" includeChildSelections="false"/>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ffdf-e734-7518-fd76" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink targetId="7799-e1d6-762b-700b" id="edfe-dac5-4e05-ecc4" primary="true" name="Paragon Model Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="f4b4-116b-22b0-c162" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="44f6-fc57-69ad-e503" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="4346-67d5-360d-89fa" id="0e7d-68fa-50ec-fd95" primary="false" name="Raven Guard"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="cd96-012e-c3fa-938d" primary="false" name="Loyalist"/>
-          </categoryLinks>
           <infoLinks>
             <infoLink name="Bulky (X)" id="120a-239a-ee4e-5f0c" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
               <modifiers>
@@ -170,9 +163,11 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="22ee-7208-4089-b005" id="def3-dc30-9bcf-73a9" primary="true" name="Warlord"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="0716-7529-46c5-48a9" primary="false" name="Loyalist"/>
-        <categoryLink targetId="4346-67d5-360d-89fa" id="c4e3-8ab7-4e8c-f9d6" primary="false" name="Raven Guard"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="e89d-577b-2707-4cd7" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="37da-21c9-3583-3f11" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="4275-cae0-07c1-e3c4" primary="false" name="Antigrav Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="d096-40ef-3299-7879" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="[Legiones Astartes]" id="169f-c439-ccd3-6b75" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
@@ -334,13 +329,6 @@ A Model with this Special Rule is never forced to make Shooting Attacks as Snap 
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="af7d-af64-6b7d-da9d" id="60ef-23a3-7dd0-4471" primary="false" name="Specialist Model Sub-Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="f52b-7e71-7aa8-ad9c" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="0fea-174e-d3f0-13de" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="2a63-160e-1ccb-c1ab" primary="false" name="Loyalist"/>
-            <categoryLink targetId="4346-67d5-360d-89fa" id="efeb-acb3-c76b-38ec" primary="false" name="Raven Guard"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <constraints>
@@ -351,9 +339,10 @@ A Model with this Special Rule is never forced to make Shooting Attacks as Snap 
         <infoLink name="[Legiones Astartes]" id="15e9-8e08-c436-f486" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="9acb-2d39-031f-c666" primary="true" name="Command"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="1573-7407-e031-26d1" primary="false" name="Loyalist"/>
-        <categoryLink targetId="4346-67d5-360d-89fa" id="0e8e-ace6-2879-809b" primary="false" name="Raven Guard"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="1d74-be95-457e-f243" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="f5bc-b516-dd0e-71d0" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="af7d-af64-6b7d-da9d" id="e5d5-872a-63d5-6ec7" primary="false" name="Specialist Model Sub-Type"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="165"/>
@@ -433,11 +422,6 @@ A Model with this Special Rule is never forced to make Shooting Attacks as Snap 
               </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="3bc5-116a-7834-1bff" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="d2d6-5a84-672b-2833" id="f150-d3bf-fb76-bf77" primary="false" name="Skirmish Model Sub-Type"/>
-            <categoryLink targetId="4346-67d5-360d-89fa" id="8788-cec8-df5e-4f28" primary="false" name="Raven Guard"/>
-          </categoryLinks>
           <costs>
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
@@ -472,9 +456,6 @@ A Model with this Special Rule is never forced to make Shooting Attacks as Snap 
           </profiles>
           <categoryLinks>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="e8e0-7645-cb66-810a" primary="false" name="Sergeant Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="5ea6-57a7-02ed-dfd1" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="d2d6-5a84-672b-2833" id="260e-cfc5-86c7-0dc6" primary="false" name="Skirmish Model Sub-Type"/>
-            <categoryLink targetId="4346-67d5-360d-89fa" id="b729-37b0-7eb2-a875" primary="false" name="Raven Guard"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="May Exchange its Nemesis Bolter for:" id="2a84-7aba-0398-3438" hidden="false" defaultSelectionEntryId="657c-9bb7-89b4-ff29" sortIndex="1">
@@ -531,8 +512,8 @@ A Model with this Special Rule is never forced to make Shooting Attacks as Snap 
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="5d5e-958f-e388-50b5" id="6f0f-1d26-9100-00d8" primary="true" name="Elites"/>
-        <categoryLink targetId="4346-67d5-360d-89fa" id="da25-8ed7-a40c-6d1d" primary="false" name="Raven Guard"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="42c7-58f7-d0e7-aa34" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="d2d6-5a84-672b-2833" id="7812-24e3-ba08-4bc6" primary="false" name="Skirmish Model Sub-Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="Infiltrate (X)" id="e0e6-8dcf-4d80-d76e" hidden="false" type="rule" targetId="f330-254e-1a98-798a">
@@ -564,11 +545,6 @@ Once per Battle, if a Unit with this Special Rule remains Stationary in the prev
     <selectionEntry type="unit" import="true" name="Dark Fury Squad" hidden="false" id="8487-ac3b-d0ec-6d08" sortIndex="4">
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Dark Fury" hidden="false" id="c88e-ddfb-6f84-acd8" sortIndex="2">
-          <categoryLinks>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="45e5-7334-5c6e-8d89" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="6867-5795-f158-9462" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="4346-67d5-360d-89fa" id="51cf-d5a5-6951-37a3" primary="false" name="Raven Guard"/>
-          </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b51d-5520-4eaa-8a54" includeChildSelections="false"/>
             <constraint type="max" value="9" field="selections" scope="parent" shared="true" id="4446-9c47-58a0-f440" includeChildSelections="false"/>
@@ -609,10 +585,7 @@ Once per Battle, if a Unit with this Special Rule remains Stationary in the prev
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Chooser of the Slain" hidden="false" id="9b5f-3411-f1b0-f87d" sortIndex="1">
           <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="1604-d86e-e170-1956" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="def8-771e-8cd7-4aed" primary="false" name="Antigrav Model Sub-Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="6604-8694-4b2d-c434" primary="false" name="Sergeant Model Sub-Type"/>
-            <categoryLink targetId="4346-67d5-360d-89fa" id="4168-fe58-6794-1b92" primary="false" name="Raven Guard"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d291-9ca4-4245-4709" includeChildSelections="false"/>
@@ -681,8 +654,8 @@ Once per Battle, if a Unit with this Special Rule remains Stationary in the prev
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="5d5e-958f-e388-50b5" id="9cfb-a556-2621-a788" primary="true" name="Elites"/>
-        <categoryLink targetId="4346-67d5-360d-89fa" id="9ee8-e63c-1f96-9540" primary="false" name="Raven Guard"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="68fb-135e-899b-c06a" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="4735-6800-586b-1914" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -698,7 +671,6 @@ Once per Battle, if a Unit with this Special Rule remains Stationary in the prev
     <entryLink import="true" name="Corvus Corax" hidden="false" id="0528-233c-3adc-04b0" type="selectionEntry" targetId="e0a6-5800-3e64-4163" sortIndex="1">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="1fab-d721-3fd4-dc4d" primary="true" name="Warlord"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="339b-5f89-e5b3-8992" primary="false" name="Loyalist"/>
         <categoryLink targetId="4346-67d5-360d-89fa" id="8801-78a1-bbc3-8ebc" primary="false" name="Raven Guard"/>
       </categoryLinks>
     </entryLink>
@@ -706,7 +678,6 @@ Once per Battle, if a Unit with this Special Rule remains Stationary in the prev
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="34e5-e8fa-ed7a-3044" primary="true" name="Command"/>
         <categoryLink targetId="4346-67d5-360d-89fa" id="0286-c407-6c5b-553e" primary="false" name="Raven Guard"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="52ba-ba58-e522-d756" primary="false" name="Loyalist"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Mor Deythan Squad" hidden="false" id="d295-c96d-41cb-d551" type="selectionEntry" targetId="4bb8-d53e-23a8-64da" sortIndex="3">

--- a/Salamanders.cat
+++ b/Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="f148-a6e4-5a8c-3aeb" name="                        XVIII - Salamanders" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="3" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="f148-a6e4-5a8c-3aeb" name="                        XVIII - Salamanders" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Firedrake Terminator Squad" hidden="false" id="09a9-6c68-9b0b-f24f" sortIndex="2">
       <selectionEntries>
@@ -25,12 +25,6 @@
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink name="Infantry Model Type" hidden="false" id="80f3-51e8-4e2c-b5ef" targetId="594d-fa82-13cb-a345" primary="true"/>
-            <categoryLink name="Heavy Model Sub-Type" hidden="false" id="379b-6347-83b6-c63d" targetId="1e7d-9066-28d2-97a0" primary="false"/>
-            <categoryLink name="Salamanders" hidden="false" id="37ee-c070-f956-55c8" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
-            <categoryLink name="Shield" hidden="false" id="3bac-b474-c90e-4b8d" targetId="26c6-e05c-0f72-7852" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="45"/>
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
@@ -66,11 +60,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink name="Infantry Model Type" hidden="false" id="81bf-f50b-298e-1b79" targetId="594d-fa82-13cb-a345" primary="true"/>
             <categoryLink name="Sergeant Model Sub-Type" hidden="false" id="a25b-be75-f4cc-78ea" targetId="8045-89a4-76d4-fcef" primary="false"/>
-            <categoryLink name="Heavy Model Sub-Type" hidden="false" id="1f0e-627d-27f8-fe49" targetId="1e7d-9066-28d2-97a0" primary="false"/>
-            <categoryLink name="Salamanders" hidden="false" id="d84b-91b2-4ac2-b1cd" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
-            <categoryLink name="Shield" hidden="false" id="ec27-f863-62e3-103d" targetId="26c6-e05c-0f72-7852" primary="false"/>
           </categoryLinks>
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8168-3156-31be-c3b2" includeChildSelections="false"/>
@@ -79,8 +69,9 @@
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink name="Elites" hidden="false" id="56de-e93e-5f15-86f6" targetId="5d5e-958f-e388-50b5" primary="true"/>
-        <categoryLink name="Salamanders" hidden="false" id="a6cd-b4de-886f-ecde" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="ceb5-f9a9-60d7-152f" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="aadb-95bd-e71f-74a4" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="473e-745e-c84b-e047" primary="false" name="Shield"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="7b96-c4b2-5a5d-4284" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -311,13 +302,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
               </modifiers>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink name="Paragon Model Type" hidden="false" id="0b38-1615-24a5-0525" targetId="7799-e1d6-762b-700b" primary="true"/>
-            <categoryLink name="Unique Model Sub-Type" hidden="false" id="e82e-c7c9-f42f-990e" targetId="b980-187b-2b17-d635" primary="false"/>
-            <categoryLink name="Salamanders" hidden="false" id="c842-f902-cc99-60b3" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
-            <categoryLink name="Loyalist" hidden="false" id="fc07-69ad-871e-a74f" targetId="4381-ed35-c3fa-a225" primary="false"/>
-            <categoryLink name="Master of the Legion" hidden="false" id="6b7c-1862-e8f8-7c6a" targetId="e3cd-7a38-34d7-9cbf" primary="false"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -343,9 +327,10 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="3ed6-4961-a06e-33be" includeChildSelections="true" includeChildForces="true"/>
       </constraints>
       <categoryLinks>
-        <categoryLink name="Warlord" hidden="false" id="ae7b-b3b7-6aa3-5279" targetId="22ee-7208-4089-b005" primary="true"/>
-        <categoryLink name="Salamanders" hidden="false" id="e726-99ad-7f2f-0f45" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
         <categoryLink name="Loyalist" hidden="false" id="aaf6-452e-c5b6-ffee" targetId="4381-ed35-c3fa-a225" primary="false"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="b513-7ac3-49cb-e828" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="a5e2-ba39-5b51-0bde" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="f322-b988-1519-b77f" primary="false" name="Master of the Legion"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Pyroclast Squad" hidden="false" id="fbbe-aa8c-d645-7970" sortIndex="3">
@@ -372,10 +357,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink name="Infantry Model Type" hidden="false" id="2bb1-43d8-c559-94f1" targetId="594d-fa82-13cb-a345" primary="true"/>
-            <categoryLink name="Salamanders" hidden="false" id="604c-b688-ae6f-d0e3" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
-          </categoryLinks>
           <costs>
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
@@ -411,9 +392,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink name="Infantry Model Type" hidden="false" id="104d-f276-b8dc-561c" targetId="594d-fa82-13cb-a345" primary="true"/>
-            <categoryLink name="Sergeant Model Sub-Type" hidden="false" id="f365-4362-4bff-f3e7" targetId="8045-89a4-76d4-fcef" primary="false"/>
-            <categoryLink name="Salamanders" hidden="false" id="cc15-f91a-9645-1699" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
+            <categoryLink targetId="8045-89a4-76d4-fcef" id="18c9-b720-7075-4f23" primary="false" name="Sergeant Model Sub-Type"/>
           </categoryLinks>
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0d9c-f010-ed2f-7048" includeChildSelections="false"/>
@@ -457,8 +436,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink name="Salamanders" hidden="false" id="3fd7-23fc-65f5-2db4" targetId="f6fe-18f5-7b4d-b57a" primary="false"/>
-        <categoryLink targetId="3235-bd79-e9b1-60fa" id="fdf8-84dc-c2a1-8789" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="ef40-da74-40b5-4b1d" primary="false" name="Infantry Model Type"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="6245-5f05-7f15-8937" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -521,9 +499,23 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
     <catalogueLink type="catalogue" name="Weapons" id="ee7a-856f-787a-e488" targetId="a22d-4dd0-c59d-57d3"/>
   </catalogueLinks>
   <entryLinks>
-    <entryLink import="true" name="Vulkan" hidden="false" id="0c0e-fb2f-fb1e-d771" type="selectionEntry" targetId="29d9-3ea2-0c2b-5c36" sortIndex="1"/>
-    <entryLink import="true" name="Firedrake Terminator Squad" hidden="false" id="e255-98b6-88b6-d0f0" type="selectionEntry" targetId="09a9-6c68-9b0b-f24f" sortIndex="2"/>
-    <entryLink import="true" name="Pyroclast Squad" hidden="false" id="7bf1-9ac3-d0ea-6229" type="selectionEntry" targetId="fbbe-aa8c-d645-7970" sortIndex="3"/>
+    <entryLink import="true" name="Vulkan" hidden="false" id="0c0e-fb2f-fb1e-d771" type="selectionEntry" targetId="29d9-3ea2-0c2b-5c36" sortIndex="1">
+      <categoryLinks>
+        <categoryLink targetId="f6fe-18f5-7b4d-b57a" id="49a9-d580-3926-71ad" primary="false" name="Salamanders"/>
+        <categoryLink targetId="22ee-7208-4089-b005" id="f5d9-e339-c9a1-e1a9" primary="true" name="Warlord"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Firedrake Terminator Squad" hidden="false" id="e255-98b6-88b6-d0f0" type="selectionEntry" targetId="09a9-6c68-9b0b-f24f" sortIndex="2">
+      <categoryLinks>
+        <categoryLink targetId="5d5e-958f-e388-50b5" id="b488-45a8-2441-ef04" primary="true" name="Elites"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Pyroclast Squad" hidden="false" id="7bf1-9ac3-d0ea-6229" type="selectionEntry" targetId="fbbe-aa8c-d645-7970" sortIndex="3">
+      <categoryLinks>
+        <categoryLink targetId="f6fe-18f5-7b4d-b57a" id="f1e0-ac2c-49b2-949a" primary="false" name="Salamanders"/>
+        <categoryLink targetId="3235-bd79-e9b1-60fa" id="70e5-2d20-c481-ba6b" primary="true" name="Heavy Assault"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedRules>
     <rule name="Promethean Endurance" id="381f-10db-0c78-f16e" hidden="false">

--- a/Sons of Horus.cat
+++ b/Sons of Horus.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="ac06-fcec-b634-5bd9" name="                        XVI - Sons of Horus" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="3" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="ac06-fcec-b634-5bd9" name="                        XVI - Sons of Horus" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Horus Lupercal" hidden="false" id="c0a2-76a5-6a6f-82bc">
       <selectionEntries>
@@ -144,9 +144,10 @@ The Controlling Player of an Army that includes a Model with this Special Rule h
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="22ee-7208-4089-b005" id="8015-088e-b803-528a" primary="true" name="Warlord"/>
         <categoryLink targetId="7799-e1d6-762b-700b" id="2a7a-cdc2-df42-89cd" primary="false" name="Paragon Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="0ca5-8b26-0260-ed09" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="198b-55ba-f3bb-994d" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="9299-b9e5-3027-100b" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="530"/>
@@ -223,11 +224,12 @@ The Controlling Player of an Army that includes a Model with this Special Rule h
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="473c-0403-69a9-b1b8" primary="true" name="High Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="d6a8-a423-d15c-3d23" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="21dc-331b-52e1-b501" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="3c00-2109-ef62-192c" primary="false" name="Command Model Sub-type"/>
         <categoryLink targetId="1e7d-9066-28d2-97a0" id="60da-1153-946d-3d08" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="f87c-7a61-d980-0617" primary="false" name="Traitor"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="119e-b9f6-178b-21c4" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="14be-cfa9-ce98-953b" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -333,10 +335,10 @@ If a Model with this Special Rule joins a Justaerin Terminator Squad Unit in Res
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="cbe3-b5a9-a485-c2a3" primary="true" name="Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="9a70-c0f2-cf5e-fb95" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="b9fa-ab5d-caa5-07a5" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="347d-1ef4-ed1d-3a33" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="13a0-b86a-655d-0c90" primary="false" name="Traitor"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Frag grenades" hidden="false" id="33c8-56e5-70bc-b502" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="4">
@@ -464,10 +466,11 @@ If a Model with this Special Rule joins a Justaerin Terminator Squad Unit in Res
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="02d2-a8f8-7647-5a97" primary="true" name="High Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="c509-49d8-20dd-483f" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="16e7-4c94-34d6-ee80" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="0db1-28a3-11a4-18c5" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="7c6d-9cfc-a6b2-0530" primary="false" name="Traitor"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="1847-66a9-6c01-88f3" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Frag grenades" hidden="false" id="ec12-df4e-8edb-64af" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="5">
@@ -648,9 +651,10 @@ A Model with this Special Rule can join Units with the Malefic Sub-Type as if it
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="22ee-7208-4089-b005" id="d647-70cd-cf93-966b" primary="true" name="Warlord"/>
         <categoryLink targetId="7799-e1d6-762b-700b" id="df2d-efea-6a66-8dfa" primary="false" name="Paragon Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="be25-38a7-b78d-bce5" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="661c-abf6-869b-96b1" primary="false" name="Traitor"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="3f27-7f65-d05e-8cb0" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Prime Unit" hidden="false" id="6b46-217a-6a8a-5ce3" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2"/>
@@ -860,7 +864,6 @@ A Model with this Special Rule can join Units with the Malefic Sub-Type as if it
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="5d5e-958f-e388-50b5" id="2f4d-b0e7-ab84-5a87" primary="true" name="Elites"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="727e-8a42-ddad-19d4" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="1e7d-9066-28d2-97a0" id="3279-cce2-8176-924d" primary="false" name="Heavy Model Sub-Type"/>
       </categoryLinks>
@@ -946,10 +949,12 @@ A Model with this Special Rule can join Units with the Malefic Sub-Type as if it
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="6d48-4c17-0a15-6f51" primary="true" name="High Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="46c9-1575-a9f7-360c" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="f874-7edb-6b6a-e57f" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="0acd-0d7a-7092-6989" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="e608-15cf-1622-6255" primary="false" name="Traitor"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="50cc-1435-027e-bdc9" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="1cd0-ab9d-fa5a-af56" primary="false" name="Shield"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Prime Unit" hidden="false" id="418d-7fcf-8f75-b96e" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2" sortIndex="6"/>
@@ -1041,10 +1046,11 @@ The Controlling Player of a Model with this Special Rule gains 2 Victory Points 
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="4e8f-159f-eeb2-5587" primary="true" name="High Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="e94b-325f-14d2-549a" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="cf38-6cd2-7301-49a9" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="5c31-01ec-950b-a4df" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="4d8b-b0dd-3563-66f1" primary="false" name="Loyalist"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="e679-2f1d-54c9-d9f2" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Bolt pistol" hidden="false" id="7540-a159-265a-7d42" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="3">
@@ -1171,10 +1177,11 @@ If the Wounds Characteristic of a Model with this Special Rule is reduced to 0 o
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="ebe7-f9fd-141e-bfe1" primary="true" name="High Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="78df-6b64-5a26-34a9" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="a6b2-008b-1f31-35f2" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="8286-88a9-352e-ed8f" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="a40c-7bef-d30f-cd17" primary="false" name="Traitor"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="3ebd-3a80-da43-0fea" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Banestrike bolter" hidden="false" id="2135-86af-8945-6bc7" type="selectionEntry" targetId="e031-bf89-67b6-744a" sortIndex="3">
@@ -1392,7 +1399,6 @@ If the Wounds Characteristic of a Model with this Special Rule is reduced to 0 o
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="3235-bd79-e9b1-60fa" id="a156-c4fa-034d-ea8a" primary="true" name="Heavy Assault"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="c074-abb7-8379-4f96" primary="false" name="Infantry Model Type"/>
       </categoryLinks>
       <entryLinks>
@@ -1481,10 +1487,10 @@ If the Wounds Characteristic of a Model with this Special Rule is reduced to 0 o
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="f6a8-a847-c3e5-fbc9" primary="true" name="Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="c7b0-fc83-1ab6-7e0f" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="dbd7-47bc-8b35-47d0" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="9391-ca3c-4d8c-7b10" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="6731-ad62-cb39-b57e" primary="false" name="Traitor"/>
       </categoryLinks>
       <entryLinks>
         <entryLink import="true" name="Banestrike bolter" hidden="false" id="847a-b45a-6019-b584" type="selectionEntry" targetId="e031-bf89-67b6-744a" sortIndex="3">
@@ -1743,16 +1749,71 @@ May have it&apos;s power sword exchanged with one frost sword or frost axe for F
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <entryLinks>
-    <entryLink import="true" name="Reaver Attack Squad" hidden="false" id="e1d7-8ba7-ade1-fc04" type="selectionEntry" targetId="8010-21cf-b606-b491"/>
-    <entryLink import="true" name="Justaerin Terminator Squad" hidden="false" id="b39e-86ad-438b-2875" type="selectionEntry" targetId="3866-f18c-3b7c-3a7e"/>
-    <entryLink import="true" name="&apos;Little&apos; Horus Aximand " hidden="false" id="3fae-2625-dafe-c987" type="selectionEntry" targetId="f9ac-f2fc-fbb3-cc37"/>
-    <entryLink import="true" name="Garviel Loken" hidden="false" id="6986-13bd-e529-305e" type="selectionEntry" targetId="ed21-80f8-e842-c972"/>
-    <entryLink import="true" name="Maloghurst the Twisted" hidden="false" id="2a53-ef08-5077-60df" type="selectionEntry" targetId="cdbb-e9d2-1c14-4a15"/>
-    <entryLink import="true" name="Tybalt Marr" hidden="false" id="34f6-b392-fd1e-e99b" type="selectionEntry" targetId="df11-d2e3-cfd8-a189"/>
-    <entryLink import="true" name="Ezekyle Abbadon" hidden="false" id="a14b-f575-14ae-c66d" type="selectionEntry" targetId="aa7d-73fa-eaac-d951"/>
-    <entryLink import="true" name="Vheren Ashurhaddon" hidden="false" id="0ea6-7c14-563b-f3b3" type="selectionEntry" targetId="6b99-8ee6-accb-c1e3"/>
-    <entryLink import="true" name="Dark Emmissary" hidden="false" id="0517-aa86-94c6-43b6" type="selectionEntry" targetId="ac51-dccb-d5ff-3d20"/>
-    <entryLink import="true" name="Horus Lupercal" hidden="false" id="4572-993b-6949-aa65" type="selectionEntry" targetId="c0a2-76a5-6a6f-82bc"/>
-    <entryLink import="true" name="Horus Ascended" hidden="false" id="0ffe-e209-c9f2-8791" type="selectionEntry" targetId="79f3-7312-bae4-da6c"/>
+    <entryLink import="true" name="Reaver Attack Squad" hidden="false" id="e1d7-8ba7-ade1-fc04" type="selectionEntry" targetId="8010-21cf-b606-b491">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="2126-896e-69a0-83dc" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="3235-bd79-e9b1-60fa" id="502a-7fb9-f86f-dcd5" primary="true" name="Heavy Assault"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Justaerin Terminator Squad" hidden="false" id="b39e-86ad-438b-2875" type="selectionEntry" targetId="3866-f18c-3b7c-3a7e">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="fa52-c149-f62d-4fd3" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="5d5e-958f-e388-50b5" id="f25a-cc76-6b69-1420" primary="true" name="Elites"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="&apos;Little&apos; Horus Aximand " hidden="false" id="3fae-2625-dafe-c987" type="selectionEntry" targetId="f9ac-f2fc-fbb3-cc37">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="ddb7-af06-cd00-2241" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="dc04-174e-fc7c-1dc9" primary="true" name="High Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Garviel Loken" hidden="false" id="6986-13bd-e529-305e" type="selectionEntry" targetId="ed21-80f8-e842-c972">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="cbd7-0989-19cf-890b" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="8f9f-8c1e-f8be-ae83" primary="true" name="High Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Maloghurst the Twisted" hidden="false" id="2a53-ef08-5077-60df" type="selectionEntry" targetId="cdbb-e9d2-1c14-4a15">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="2531-922d-0812-737a" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="6dbf-654a-f06f-2d69" id="7a7e-7d88-c7e5-8a04" primary="true" name="Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Tybalt Marr" hidden="false" id="34f6-b392-fd1e-e99b" type="selectionEntry" targetId="df11-d2e3-cfd8-a189">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="92ee-0bb6-6278-562f" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="fe19-9aba-b0e6-3c33" primary="true" name="High Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Ezekyle Abbadon" hidden="false" id="a14b-f575-14ae-c66d" type="selectionEntry" targetId="aa7d-73fa-eaac-d951">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="d15b-0a85-7f76-e1b4" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="a074-8d4b-fc76-9d31" primary="true" name="High Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Vheren Ashurhaddon" hidden="false" id="0ea6-7c14-563b-f3b3" type="selectionEntry" targetId="6b99-8ee6-accb-c1e3">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="2dc4-ee58-c3cf-6cff" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="1240-9cdb-4ead-7897" primary="true" name="High Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Dark Emmissary" hidden="false" id="0517-aa86-94c6-43b6" type="selectionEntry" targetId="ac51-dccb-d5ff-3d20">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="646a-aad8-718d-f7e5" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="6dbf-654a-f06f-2d69" id="678b-1f1e-1747-aafb" primary="true" name="Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Horus Lupercal" hidden="false" id="4572-993b-6949-aa65" type="selectionEntry" targetId="c0a2-76a5-6a6f-82bc">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="aca8-6fbc-7868-6868" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="22ee-7208-4089-b005" id="4339-265e-3409-c575" primary="true" name="Warlord"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Horus Ascended" hidden="false" id="0ffe-e209-c9f2-8791" type="selectionEntry" targetId="79f3-7312-bae4-da6c">
+      <categoryLinks>
+        <categoryLink targetId="3b0c-6e3a-f5cd-02cd" id="1101-87f7-dc67-0533" primary="false" name="Sons of Horus"/>
+        <categoryLink targetId="22ee-7208-4089-b005" id="a973-6798-77aa-e9a3" primary="true" name="Warlord"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
 </catalogue>

--- a/Space Wolves.cat
+++ b/Space Wolves.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="d995-cb33-be41-ecf8" name="                         VI - Space Wolves" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="d995-cb33-be41-ecf8" name="                         VI - Space Wolves" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="6" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Assets" id="db71-05b7-0cff-28d1" importRootEntries="true" targetId="5334-5605-242c-d75e"/>
     <catalogueLink type="catalogue" name="Legiones Astartes" id="17f0-6633-7613-e326" importRootEntries="true" targetId="9b32-f350-6aa9-9c09"/>
@@ -132,9 +132,9 @@ Howl of the Death Wolf: Once this Gambit is selected and until it&apos;s effects
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="22ee-7208-4089-b005" id="5801-0a82-c072-74b2" primary="true" name="Warlord"/>
         <categoryLink targetId="7799-e1d6-762b-700b" id="3cb2-5406-8465-95ed" primary="false" name="Paragon Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="5624-adee-092c-bbe9" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="2d81-baa6-7c4f-1448" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="450"/>
@@ -175,7 +175,6 @@ Howl of the Death Wolf: Once this Gambit is selected and until it&apos;s effects
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Deathsworn Pack" hidden="false" id="cb82-a73f-b30f-c30f" publicationId="b905-0414-1057-bb34" page="176">
       <categoryLinks>
-        <categoryLink targetId="3235-bd79-e9b1-60fa" id="6046-671e-4f32-16f7" primary="true" name="Heavy Assault"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="648d-2b11-ae71-dd6e" primary="false" name="Infantry Model Type"/>
       </categoryLinks>
       <selectionEntries>
@@ -280,11 +279,11 @@ Howl of the Death Wolf: Once this Gambit is selected and until it&apos;s effects
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Geigor Fell-Hand" hidden="false" id="8280-b241-c837-f3ca" publicationId="b905-0414-1057-bb34" page="171">
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="40e0-83d0-d68c-8a92" primary="true" name="Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="ba12-9568-20ab-b57f" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="65eb-af9e-402d-ca0a" primary="false" name="Command Model Sub-type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="5945-81a4-a3e4-7ed9" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="901a-6b71-7a29-4597" id="4656-9215-3a61-2d1f" primary="false" name="Officer of the Line (2)"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="2070-de62-d5a0-889a" primary="false" name="Loyalist"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="105"/>
@@ -400,7 +399,6 @@ Howl of the Death Wolf: Once this Gambit is selected and until it&apos;s effects
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Grey Slayer Pack" hidden="false" id="9a43-13b5-bd92-d8be" publicationId="b905-0414-1057-bb34" page="177">
       <categoryLinks>
-        <categoryLink targetId="88e6-d373-4152-0dd8" id="e020-ad87-c442-be7c" primary="true" name="Troops"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="299f-0c0e-e77b-5849" primary="false" name="Infantry Model Type"/>
       </categoryLinks>
       <selectionEntries>
@@ -742,10 +740,11 @@ Howl of the Death Wolf: Once this Gambit is selected and until it&apos;s effects
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hvarl Red-Blade" hidden="false" id="a681-0e72-a7fa-7bdd" publicationId="b905-0414-1057-bb34" page="170">
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="8f82-96f2-73e6-ae4e" primary="true" name="Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="28fb-11c5-2d77-c2df" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="1809-56d2-68ae-58ce" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="15d4-e03c-0145-c3dc" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="ff15-598e-30d6-4722" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="30b4-5911-a14a-e13a" primary="false" name="Loyalist"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="210"/>
@@ -962,14 +961,12 @@ Head-taker: If this Gambit is selected, the Opposing Player may not claim an Out
         <entryLink import="true" name="Prime Unit" hidden="false" id="fc0c-4f2b-f51f-a41c" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2"/>
       </entryLinks>
       <categoryLinks>
-        <categoryLink targetId="3235-bd79-e9b1-60fa" id="d22b-36f8-b2cb-783d" primary="true" name="Heavy Assault"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="e37c-58f6-a845-2a11" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="1e7d-9066-28d2-97a0" id="22f0-9268-620c-e6d0" primary="false" name="Heavy Model Sub-Type"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Wolf-kin of Russ" hidden="false" id="ce16-cc72-704a-bd2d" publicationId="b905-0414-1057-bb34" page="174">
       <categoryLinks>
-        <categoryLink targetId="a38e-50ff-310f-f19e" id="8049-9237-783c-5193" primary="true" name="Retinue"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="86a4-a7ef-b663-8399" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="2533-8e21-84d6-61fd" primary="false" name="Unique Model Sub-Type"/>
       </categoryLinks>
@@ -1098,9 +1095,9 @@ Head-taker: If this Gambit is selected, the Opposing Player may not claim an Out
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Caster of Runes" hidden="false" id="0fe3-fde9-4086-e3ab" publicationId="b905-0414-1057-bb34" page="172">
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="23be-aeb9-eb69-41c9" primary="true" name="Command"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="d44f-7067-986c-1ec8" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="08dc-ea9c-e9e8-de5c" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="9cd2-10ba-bfd3-12d1" primary="false" name="Psyker"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="110"/>
@@ -1340,9 +1337,24 @@ Head-taker: If this Gambit is selected, the Opposing Player may not claim an Out
     </selectionEntry>
   </sharedSelectionEntries>
   <entryLinks>
-    <entryLink import="true" name="Deathsworn Pack" hidden="false" id="b0bd-300f-59df-f92e" type="selectionEntry" targetId="cb82-a73f-b30f-c30f"/>
-    <entryLink import="true" name="Caster of Runes" hidden="false" id="ba33-40ec-d766-6408" type="selectionEntry" targetId="0fe3-fde9-4086-e3ab"/>
-    <entryLink import="true" name="Geigor Fell-Hand" hidden="false" id="48ab-ffac-313a-7708" type="selectionEntry" targetId="8280-b241-c837-f3ca"/>
+    <entryLink import="true" name="Deathsworn Pack" hidden="false" id="b0bd-300f-59df-f92e" type="selectionEntry" targetId="cb82-a73f-b30f-c30f">
+      <categoryLinks>
+        <categoryLink targetId="f804-d214-a195-58e7" id="9194-599c-05dc-1742" primary="false" name="Space Wolves"/>
+        <categoryLink targetId="3235-bd79-e9b1-60fa" id="0044-19b1-3b18-a672" primary="true" name="Heavy Assault"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Caster of Runes" hidden="false" id="ba33-40ec-d766-6408" type="selectionEntry" targetId="0fe3-fde9-4086-e3ab">
+      <categoryLinks>
+        <categoryLink targetId="f804-d214-a195-58e7" id="2d96-338a-4021-73cd" primary="false" name="Space Wolves"/>
+        <categoryLink targetId="6dbf-654a-f06f-2d69" id="a062-bc0b-14b5-ff85" primary="true" name="Command"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Geigor Fell-Hand" hidden="false" id="48ab-ffac-313a-7708" type="selectionEntry" targetId="8280-b241-c837-f3ca">
+      <categoryLinks>
+        <categoryLink targetId="f804-d214-a195-58e7" id="6f24-990d-d1b9-f2f3" primary="false" name="Space Wolves"/>
+        <categoryLink targetId="6dbf-654a-f06f-2d69" id="7077-2a0c-c8b4-4826" primary="true" name="Command"/>
+      </categoryLinks>
+    </entryLink>
     <entryLink import="true" name="Grey Slayer Pack" hidden="false" id="0171-c81f-3045-617e" type="selectionEntry" targetId="9a43-13b5-bd92-d8be">
       <modifiers>
         <modifier type="set-primary" value="a4aa-d941-3aab-a81b" field="category">
@@ -1351,11 +1363,35 @@ Head-taker: If this Gambit is selected, the Opposing Player may not claim an Out
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="f804-d214-a195-58e7" id="7910-67ba-a631-5d38" primary="false" name="Space Wolves"/>
+        <categoryLink targetId="88e6-d373-4152-0dd8" id="eb5d-386a-d636-803f" primary="true" name="Troops"/>
+      </categoryLinks>
     </entryLink>
-    <entryLink import="true" name="Hvarl Red-Blade" hidden="false" id="1c16-1b01-9abd-5cb9" type="selectionEntry" targetId="a681-0e72-a7fa-7bdd"/>
-    <entryLink import="true" name="Leman Russ" hidden="false" id="816c-fff9-b834-bec8" type="selectionEntry" targetId="e308-c9ee-3be5-0f71"/>
-    <entryLink import="true" name="Varagyr Wolf Guard Terminators" hidden="false" id="874a-10f5-f218-8df0" type="selectionEntry" targetId="efd1-c611-841f-0cbb"/>
-    <entryLink import="true" name="Wolf-kin of Russ" hidden="false" id="676e-7dbf-8fa7-11e5" type="selectionEntry" targetId="ce16-cc72-704a-bd2d"/>
+    <entryLink import="true" name="Hvarl Red-Blade" hidden="false" id="1c16-1b01-9abd-5cb9" type="selectionEntry" targetId="a681-0e72-a7fa-7bdd">
+      <categoryLinks>
+        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="32ca-b611-c0b1-7474" primary="true" name="High Command"/>
+        <categoryLink targetId="f804-d214-a195-58e7" id="bf68-1260-b019-4d71" primary="false" name="Space Wolves"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Leman Russ" hidden="false" id="816c-fff9-b834-bec8" type="selectionEntry" targetId="e308-c9ee-3be5-0f71">
+      <categoryLinks>
+        <categoryLink targetId="f804-d214-a195-58e7" id="49c2-7d93-c048-a1d0" primary="false" name="Space Wolves"/>
+        <categoryLink targetId="22ee-7208-4089-b005" id="a4fd-6c06-7a7f-36d6" primary="true" name="Warlord"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Varagyr Wolf Guard Terminators" hidden="false" id="874a-10f5-f218-8df0" type="selectionEntry" targetId="efd1-c611-841f-0cbb">
+      <categoryLinks>
+        <categoryLink targetId="f804-d214-a195-58e7" id="af9e-d6d6-7a0e-761a" primary="false" name="Space Wolves"/>
+        <categoryLink targetId="5d5e-958f-e388-50b5" id="2c3e-0f05-a6a2-bae7" primary="true" name="Elites"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Wolf-kin of Russ" hidden="false" id="676e-7dbf-8fa7-11e5" type="selectionEntry" targetId="ce16-cc72-704a-bd2d">
+      <categoryLinks>
+        <categoryLink targetId="f804-d214-a195-58e7" id="8c19-4f11-59c8-e6dc" primary="false" name="Space Wolves"/>
+        <categoryLink targetId="a38e-50ff-310f-f19e" id="1de5-4d5e-2fe6-a32e" primary="true" name="Retinue"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Frost Blades" id="dd5d-da62-8038-38f1" hidden="false" defaultSelectionEntryId="198c-326a-8b72-2bb9">

--- a/Thousand Sons.cat
+++ b/Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Magnus the Red" hidden="false" id="cf2e-fa27-23ce-7502">
       <selectionEntries>
@@ -173,15 +173,6 @@
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <categoryLinks>
-            <categoryLink targetId="22ee-7208-4089-b005" id="14bc-c24d-9237-5390" primary="false" name="Warlord"/>
-            <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="2b74-db86-8de9-fc98" primary="false" name="Thousand Sons"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="3d9e-e833-d2e6-7858" primary="false" name="Master of the Legion"/>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="e6db-75f9-b406-fc7b" primary="false" name="Psyker"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="beb4-63d4-ca8c-e6b5" primary="false" name="Traitor"/>
-            <categoryLink targetId="7799-e1d6-762b-700b" id="8b0d-a1fe-81fa-a4bd" primary="false" name="Paragon Model Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="c86f-9739-feb5-e8e0" primary="false" name="Unique Model Sub-Type"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Psyfire Serpenta" hidden="false" id="789e-8295-a1f6-303c" sortIndex="2" flatten="false">
               <constraints>
@@ -257,6 +248,13 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
       <constraints>
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="f4a4-d9f1-9a77-e812" includeChildSelections="true"/>
       </constraints>
+      <categoryLinks>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="25be-a32c-91e3-0653" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="6aa1-9b9d-77be-6ffa" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="c7a0-a1d3-5651-e385" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="8258-3fbd-8976-7e5c" primary="false" name="Psyker"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="5ce9-a452-29cc-8ed0" primary="false" name="Traitor"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ahzek Ahriman" hidden="false" id="1b93-d5ce-f6d7-8ad2">
       <selectionEntries>
@@ -297,15 +295,6 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
           </costs>
-          <categoryLinks>
-            <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="23ab-10a6-ad70-f903" primary="false" name="Thousand Sons"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="75ee-fd40-098b-e83e" primary="false" name="Traitor"/>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="0f43-b94d-dec0-3f74" primary="false" name="Psyker"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="459b-de86-1a0b-603a" primary="false" name="Master of the Legion"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="fa6c-edfc-75db-8cc5" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="0ae4-394e-475c-ad7e" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="6dbf-654a-f06f-2d69" id="b86b-af69-81ce-b5bd" primary="false" name="Command"/>
-          </categoryLinks>
           <infoLinks>
             <infoLink name="Prosperine Arcana" id="c04b-0426-c88e-25ed" hidden="false" type="rule" targetId="4af2-be40-b027-468a"/>
             <infoLink name="Cult Arcana" id="1227-ad6c-ee0d-cac7" hidden="false" type="rule" targetId="f622-94c0-3997-9ee5"/>
@@ -405,6 +394,14 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="c2e4-b0a2-c80a-78af" primary="false" name="Traitor"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="47e1-793e-a9e5-4cc3" primary="false" name="Psyker"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="ff6a-88e7-dd35-c1e0" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="9c4b-940a-14da-fc97" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="d730-7a38-2475-e758" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="434d-b9ab-8247-152f" primary="false" name="Command Model Sub-type"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Athanaean" hidden="false" id="b82f-e92e-222b-37e0">
       <costs>
@@ -637,15 +634,6 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="10d9-e34f-47d1-3df5-min" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="10d9-e34f-47d1-3df5-max" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="26cc-3ad1-9e62-633e" primary="false" name="Traitor"/>
-            <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="50e8-19dd-b9e4-e538" primary="false" name="Thousand Sons"/>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="4acb-7da3-d8de-0f64" primary="false" name="Psyker"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="b2df-4c4a-ee4d-ffd5" primary="false" name="Master of the Legion"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="a1bd-ef60-da33-dfce" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="3f0a-de46-7869-18df" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="6dbf-654a-f06f-2d69" id="942f-e0bf-e6aa-7ff9" primary="false" name="Command"/>
-          </categoryLinks>
           <profiles>
             <profile name="Magistus Amon" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="253d-02a2-92b0-c8ea" publicationId="e54c-7040-0f35-d85d">
               <characteristics>
@@ -789,6 +777,14 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="4ad7-1975-aa28-2e9f" primary="false" name="Traitor"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="ced3-4f0d-8c0e-43f4" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="b8ad-3cd2-b18c-3ccd" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="bfdb-a6d3-c6ed-262c" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="5dd0-a3aa-8e11-c409" primary="false" name="Psyker"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="f83a-5d7f-b9cf-06c1" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Prosperine Sorcerer" hidden="false" id="62bf-2931-3aab-3937">
       <selectionEntries>
@@ -941,10 +937,6 @@ Immovable Force (Telekinesis Discipline)</description>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <categoryLinks>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="87b7-72e6-e4bc-d5fa" primary="false" name="Psyker"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="c646-5e3c-6d47-4b89" primary="false" name="Infantry Model Type"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Bolt pistol" hidden="false" id="4d1d-1133-ce0a-d1fd" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="2">
               <constraints>
@@ -974,6 +966,11 @@ Immovable Force (Telekinesis Discipline)</description>
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="93a0-60ae-52bd-c71f" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="06a9-54e0-6c7f-6b88" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="23b7-f5bb-1565-b6ce" primary="false" name="Psyker"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sekhmet Terminator Cabal" hidden="false" id="c5a4-8dfe-5b4c-eef2">
       <selectionEntries>
@@ -1122,10 +1119,7 @@ Immovable Force (Telekinesis Discipline)</description>
             <entryLink import="true" name="Legiones Astartes Trait" hidden="false" id="b9ca-cba0-2ab1-d439" type="selectionEntryGroup" targetId="3014-5f25-bc3b-4675"/>
           </entryLinks>
           <categoryLinks>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="6ccf-1e07-6d4a-1363" primary="false" name="Psyker"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="1d8e-39f0-ebeb-52c0" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="9cac-64bc-136b-359c" primary="false" name="Sergeant Model Sub-Type"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="bb91-dd97-9c15-4e1a" primary="false" name="Heavy Model Sub-Type"/>
           </categoryLinks>
         </selectionEntry>
         <selectionEntry type="model" import="true" name="Sekhmet" hidden="false" id="cc44-6a6f-b9c7-c772" sortIndex="2">
@@ -1282,11 +1276,6 @@ Immovable Force (Telekinesis Discipline)</description>
             <entryLink import="true" name="Allegiance Traits" hidden="false" id="f1c2-38cc-aca4-6ab5" type="selectionEntryGroup" targetId="edd3-9763-97ca-0323"/>
             <entryLink import="true" name="Legiones Astartes Trait" hidden="false" id="c9de-4227-4590-06f8" type="selectionEntryGroup" targetId="3014-5f25-bc3b-4675"/>
           </entryLinks>
-          <categoryLinks>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="832e-924b-da84-1eb2" primary="false" name="Psyker"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="89e2-f7b3-63a2-adf4" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="1e7d-9066-28d2-97a0" id="8417-bc0a-e983-7abf" primary="false" name="Heavy Model Sub-Type"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1311,6 +1300,11 @@ Immovable Force (Telekinesis Discipline)</description>
         <infoLink name="Slow and Purposeful" id="5f87-c024-1696-2050" hidden="false" type="rule" targetId="6a8e-e508-abc9-cb3e"/>
         <infoLink name="Cult Arcana" id="de54-ca29-2ab0-5a99" hidden="false" type="rule" targetId="f622-94c0-3997-9ee5"/>
       </infoLinks>
+      <categoryLinks>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="4b93-a0cc-6f5d-a89f" primary="false" name="Psyker"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="955e-3a8e-4d58-3428" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="1976-c1f2-b7fd-5de2" primary="false" name="Heavy Model Sub-Type"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Achea pattern force sword" hidden="false" id="936c-e098-1e3b-ca96">
       <profiles>
@@ -1416,9 +1410,6 @@ Immovable Force (Telekinesis Discipline)</description>
             <entryLink import="true" name="Legiones Astartes Trait" hidden="false" id="e6f4-a3ad-2a4f-d2b6" type="selectionEntryGroup" targetId="3014-5f25-bc3b-4675"/>
           </entryLinks>
           <categoryLinks>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="99ca-cf33-b1c4-150d" primary="false" name="Psyker"/>
-            <categoryLink targetId="6101-2133-e9a7-0ea9" id="b2c4-5ef9-3a03-892a" primary="false" name="Khenetai"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="f34c-b4df-03b0-b04f" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="8438-26ca-a024-154e" primary="false" name="Sergeant Model Sub-Type"/>
           </categoryLinks>
         </selectionEntry>
@@ -1547,6 +1538,10 @@ The &apos;Khenetai&apos; Trait</description>
           </constraints>
         </entryLink>
       </entryLinks>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="c9f1-b4d2-5ba5-12af" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="4525-6275-5b4e-0462" primary="false" name="Psyker"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Contemptor-Osiron Dreadnought" hidden="false" id="6580-3281-36a9-564a">
       <selectionEntries>
@@ -1555,11 +1550,6 @@ The &apos;Khenetai&apos; Trait</description>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ffc6-f725-d0d8-69dc" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7c2f-4640-611a-a447" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="0a1a-eff5-f5d0-7e14" primary="false" name="Psyker"/>
-            <categoryLink targetId="49fc-361e-9168-c460" id="9fce-92ba-a067-886e" primary="false" name="Smokescreen"/>
-            <categoryLink targetId="38d4-d720-8009-acd3" id="7aff-c5fc-3361-daaa" primary="false" name="Walker Model Type"/>
-          </categoryLinks>
           <profiles>
             <profile name="Contemptor-Osiron Dreadnought" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="6fa6-595e-0d36-f4bc" publicationId="e54c-7040-0f35-d85d">
               <characteristics>
@@ -1741,6 +1731,11 @@ The &apos;Khenetai&apos; Trait</description>
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="38d4-d720-8009-acd3" id="6533-d360-96ff-c2da" primary="false" name="Walker Model Type"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="2bff-6dc6-e39d-bb34" primary="false" name="Psyker"/>
+        <categoryLink targetId="49fc-361e-9168-c460" id="8299-e6c3-0780-5ea0" primary="false" name="Smokescreen"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Castellax-Achea Automata" hidden="false" id="8372-11b0-af24-4996">
       <selectionEntries>
@@ -1749,9 +1744,6 @@ The &apos;Khenetai&apos; Trait</description>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6b46-11a0-2494-3e5b" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e786-f61b-36d0-08f5" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink targetId="5833-5e86-26bc-0916" id="a46e-3f0f-f584-80cf" primary="false" name="Automata Model Type"/>
-          </categoryLinks>
           <profiles>
             <profile name="Castellax-Achea" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="616d-0041-de47-322f" publicationId="e54c-7040-0f35-d85d">
               <characteristics>
@@ -1933,6 +1925,9 @@ the Psychic Power was from a Prosperine Arcana to a Model in this Unit instead. 
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="5833-5e86-26bc-0916" id="3593-c6ea-918f-621b" primary="false" name="Automata Model Type"/>
+      </categoryLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <catalogueLinks>
@@ -2051,41 +2046,49 @@ the Psychic Power was from a Prosperine Arcana to a Model in this Unit instead. 
     <entryLink import="true" name="Magnus the Red" hidden="false" id="2d3f-a65d-edd7-847b" type="selectionEntry" targetId="cf2e-fa27-23ce-7502">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="7e97-6436-67f2-98f2" primary="true" name="Warlord"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="372d-b7ff-acec-b2d2" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Ahzek Ahriman" hidden="false" id="6585-dd01-4a66-3422" type="selectionEntry" targetId="1b93-d5ce-f6d7-8ad2">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="763c-c312-65cd-0c8c" primary="true" name="High Command"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="99fa-e49f-f944-b789" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Castellax-Achea Automata" hidden="false" id="4e95-8076-b824-8c02" type="selectionEntry" targetId="8372-11b0-af24-4996">
       <categoryLinks>
         <categoryLink targetId="345f-9ba6-9b02-ed5c" id="797d-d6f4-c350-64b0" primary="true" name="Support"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="0fb3-e082-52c2-9916" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Magistus Amon" hidden="false" id="b509-f1ce-4a4d-4b90" type="selectionEntry" targetId="b0a0-fbcd-0605-47df">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="7d60-fd76-85fe-4f75" primary="true" name="High Command"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="9035-08e0-ad86-1192" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Prosperine Sorcerer" hidden="false" id="4bb2-4c28-439d-6074" type="selectionEntry" targetId="62bf-2931-3aab-3937">
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="c2a7-8ca0-c3a8-885a" primary="true" name="Command"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="1b5d-3ecf-5774-73b1" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Khenetai Occult Cabal" hidden="false" id="0e9e-1fd6-40aa-5236" type="selectionEntry" targetId="3f0f-9a7b-bd90-8fd3">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="380b-5461-7600-b26a" primary="true" name="Elites"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="259d-b72b-002c-b7c5" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Sekhmet Terminator Cabal" hidden="false" id="6b76-ee97-f18f-5538" type="selectionEntry" targetId="c5a4-8dfe-5b4c-eef2">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="cfd2-9d2b-0b08-4ffb" primary="true" name="Elites"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="39a0-63c7-383a-d9f4" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Contemptor-Osiron Dreadnought" hidden="false" id="1ee2-34ab-cb0e-3b25" type="selectionEntry" targetId="6580-3281-36a9-564a">
       <categoryLinks>
         <categoryLink targetId="2499-7239-685f-8465" id="f52b-f1b9-b782-5431" primary="true" name="War-engine"/>
+        <categoryLink targetId="7c3f-93c7-d5b9-89e3" id="e776-be0c-df58-5e88" primary="false" name="Thousand Sons"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/Ultramarines.cat
+++ b/Ultramarines.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="656a-07b6-d4fd-57af" name="                        XIII - Ultramarines" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="3" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="656a-07b6-d4fd-57af" name="                        XIII - Ultramarines" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Roboute Guilliman" hidden="false" id="8b5a-f212-1993-60bb" publicationId="b905-0414-1057-bb34" page="248">
       <selectionEntries>
@@ -38,6 +38,12 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="0971-d966-601d-a9fa" primary="false" name="Loyalist"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="16da-1c4d-849f-c927" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="8786-16be-7ac2-a5a8" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="817a-12ae-5c8e-6615" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Legatine Axe" hidden="false" id="09d3-f895-42de-143d">
       <profiles>
@@ -83,14 +89,15 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6384-6fb3-4789-edc3-min" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6384-6fb3-4789-edc3-max" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink name="Officer of the Line (2)" hidden="false" id="674f-3b0b-ac23-ebec" targetId="901a-6b71-7a29-4597" primary="false"/>
-            <categoryLink name="Infantry Model Type" hidden="false" id="0842-744e-ef5d-710f" targetId="594d-fa82-13cb-a345" primary="false"/>
-            <categoryLink name="Unique Model Sub-Type" hidden="false" id="2967-c23a-f510-9e9d" targetId="b980-187b-2b17-d635" primary="false"/>
-            <categoryLink name="Command Model Sub-type" hidden="false" id="a2bd-47b8-2c3e-d60b" targetId="9871-cb62-5283-2216" primary="false"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
+      <categoryLinks>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="65ae-dfb5-1638-d7e7" primary="false" name="Loyalist"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="ca4b-ad3a-3585-ea7a" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="cee6-28ee-e7f3-9b4f" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="6902-13ba-19a8-ff76" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="901a-6b71-7a29-4597" id="5596-0a4d-205f-d1a9" primary="false" name="Officer of the Line (2)"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Invictus Suzerain Squad" hidden="false" id="3a11-d72b-2f04-cc62">
       <costs>
@@ -110,7 +117,7 @@
             <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="dd2e-821c-4798-464d" includeChildSelections="false"/>
           </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup name="New Group" id="6fd8-dd70-1476-5da1" hidden="false">
+            <selectionEntryGroup name="Ranged weapon:" id="6fd8-dd70-1476-5da1" hidden="false">
               <selectionEntryGroups>
                 <selectionEntryGroup name="2 in 5 may exchange their bolt pistol for:" id="ded0-8c97-e606-3a66" hidden="false">
                   <entryLinks>
@@ -140,6 +147,11 @@
           </selectionEntryGroups>
         </selectionEntry>
       </selectionEntries>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="73d7-857d-a77e-e77d" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="b31c-e3b6-f11d-56e0" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="01e5-f6bc-4a3f-cd1b" primary="false" name="Shield"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Praetorian Breacher Squad" hidden="false" id="f115-4466-aa86-b446">
       <selectionEntries>
@@ -236,6 +248,11 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="298e-98c5-c3d5-66bd" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="1e7d-9066-28d2-97a0" id="5b00-f48f-c54c-5388" primary="false" name="Heavy Model Sub-Type"/>
+        <categoryLink targetId="26c6-e05c-0f72-7852" id="e8d3-5fac-9cec-3151" primary="false" name="Shield"/>
+      </categoryLinks>
     </selectionEntry>
   </sharedSelectionEntries>
   <catalogueLinks>
@@ -250,21 +267,25 @@
     <entryLink import="true" name="Roboute Guilliman" hidden="false" id="5a54-9d3a-c0a8-dac8" targetId="8b5a-f212-1993-60bb" type="selectionEntry">
       <categoryLinks>
         <categoryLink name="Warlord" hidden="false" id="9f79-d19c-049e-f6d3" targetId="22ee-7208-4089-b005" primary="true"/>
+        <categoryLink targetId="7fcf-5885-0a4d-ee31" id="2924-be5f-af46-676e" primary="false" name="Ultramarines"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Reman Ventanus" hidden="false" id="200b-4e53-cc72-f9a1" targetId="997b-95c4-dc66-a5f8" type="selectionEntry">
       <categoryLinks>
         <categoryLink name="Command" hidden="false" id="3a63-5c40-4637-9682" targetId="6dbf-654a-f06f-2d69" primary="true"/>
+        <categoryLink targetId="7fcf-5885-0a4d-ee31" id="fbdf-0406-5794-ca56" primary="false" name="Ultramarines"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Invictus Suzerain Squad" hidden="false" id="ff65-1f4a-ab24-12ef" targetId="3a11-d72b-2f04-cc62" type="selectionEntry">
       <categoryLinks>
         <categoryLink name="Elites" hidden="false" id="1fda-785b-0c4c-4aa3" targetId="5d5e-958f-e388-50b5" primary="true"/>
+        <categoryLink targetId="7fcf-5885-0a4d-ee31" id="a40a-79bd-aa7a-1095" primary="false" name="Ultramarines"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Praetorian Breacher Squad" hidden="false" id="b0f9-fbe4-6e4f-f630" targetId="f115-4466-aa86-b446" type="selectionEntry">
       <categoryLinks>
         <categoryLink name="Heavy Assault" hidden="false" id="2be2-40e8-ab05-fb31" targetId="3235-bd79-e9b1-60fa" primary="true"/>
+        <categoryLink targetId="7fcf-5885-0a4d-ee31" id="07a1-397c-87db-cd6b" primary="false" name="Ultramarines"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/White Scars.cat
+++ b/White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="f7b4-2531-0962-1379" name="                         V - White Scars" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="3" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="f7b4-2531-0962-1379" name="                         V - White Scars" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Jaghatai Khan" hidden="false" id="8192-47ac-99f9-73e9" sortIndex="1">
       <selectionEntries>
@@ -29,13 +29,6 @@
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a1a0-fd8e-2d8c-91f7" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3f4d-6cb8-cd9a-6e59" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink targetId="a46f-a465-0ead-d6b8" id="8e02-facf-f0a2-a208" primary="false" name="Lord of War"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="e0f6-24b8-27e1-0a01" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="7799-e1d6-762b-700b" id="5978-eb56-7179-7bb7" primary="true" name="Paragon Model Type"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="33f6-6e31-1bad-3bdc" primary="false" name="Loyalist"/>
-            <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="75d4-1cf7-f9f2-5f69" primary="false" name="White Scars"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Storm&apos;s Voice" hidden="false" id="0838-482c-85f1-dd80" publicationId="b905-0414-1057-bb34" sortIndex="2">
               <profiles>
@@ -142,8 +135,10 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="22ee-7208-4089-b005" id="3b41-1bc4-8eb2-2359" primary="true" name="Warlord"/>
-        <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="3b01-6d0c-f87c-0181" primary="false" name="White Scars"/>
+        <categoryLink targetId="4381-ed35-c3fa-a225" id="e42a-23e3-9647-7b0e" primary="false" name="Loyalist"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="5dd8-9176-6ecf-1f19" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="ad4a-7818-0cbf-c680" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="dae5-2371-6ea5-7bbe" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -179,13 +174,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
     <selectionEntry type="unit" import="true" name="Qin Xa" hidden="false" id="0935-9158-92d0-5528" publicationId="b905-0414-1057-bb34" sortIndex="2">
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Qin Xa" hidden="false" id="3612-7539-b8a1-ac02" publicationId="b905-0414-1057-bb34">
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="cbca-e38c-a709-40cf" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="f276-d0cd-91f6-3c88" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="f171-2011-58ba-4646" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="beae-ca46-de5e-4b61" primary="false" name="Loyalist"/>
-            <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="d5bf-80a1-1db1-aa34" primary="false" name="White Scars"/>
-          </categoryLinks>
           <profiles>
             <profile name="Qin Xa" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="8da9-7f3d-2e61-213f" publicationId="b905-0414-1057-bb34">
               <characteristics>
@@ -267,9 +255,11 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <infoLink name="Master of the Legion" id="828a-f53c-6eb1-01c5" hidden="false" type="profile" targetId="6cd2-96be-b703-6d57"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="c796-3a6a-660e-af86" primary="true" name="High Command"/>
-        <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="7bc6-2f77-979b-9b8d" primary="false" name="White Scars"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="93f6-506e-cd5b-2bd4" primary="false" name="Loyalist"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="a92d-b07a-518b-d7e5" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="8800-f99a-7d03-c911" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="00b0-f7fd-b054-eaaa" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="b5b7-87df-5d82-2377" primary="false" name="Master of the Legion"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -278,14 +268,13 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
           </conditions>
         </modifier>
       </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="8f9a-21d8-cb62-1e69" type="selectionEntry" targetId="31c4-c9d1-fdba-4b21"/>
+      </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Stormseer" hidden="false" id="5123-b5ea-c6dc-7bb9" publicationId="b905-0414-1057-bb34" sortIndex="4">
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Stormseer" hidden="false" id="c45b-d7b8-0dfd-3dbe" publicationId="b905-0414-1057-bb34" sortIndex="0">
-          <categoryLinks>
-            <categoryLink targetId="9871-cb62-5283-2216" id="a2ac-c4a9-9d65-f90d" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="82ad-7db9-7b66-fd80" primary="true" name="Infantry Model Type"/>
-          </categoryLinks>
           <profiles>
             <profile name="Stormseer" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="aa36-64a0-92d4-22ae" publicationId="b905-0414-1057-bb34">
               <characteristics>
@@ -430,8 +419,9 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="5bb2-a602-9a2a-eb05" primary="true" name="Command"/>
-        <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="df24-b87e-cd6c-527b" primary="false" name="White Scars"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="4347-58fc-46ee-0d3d" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="a956-a776-aee8-c4d9" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="7052-7461-40ce-c2a7" primary="false" name="Psyker"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="46ea-01cc-7ca9-c4ff" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -442,14 +432,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
     <selectionEntry type="unit" import="true" name="Hibou Khan" hidden="false" id="fd81-80fc-3d80-5f8b" publicationId="b905-0414-1057-bb34" sortIndex="3">
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Hibou Khan" hidden="false" id="ea88-3b4e-ddd8-57fa" publicationId="b905-0414-1057-bb34" sortIndex="0">
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="a23f-2344-116e-15fb" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="3e5f-a52a-0881-7e44" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="901a-6b71-7a29-4597" id="4f4e-33d1-1ace-8054" primary="false" name="Officer of the Line (2)"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="d454-d254-24c3-8f43" primary="true" name="Infantry Model Type"/>
-            <categoryLink targetId="4381-ed35-c3fa-a225" id="f709-3ba0-6ca8-e6e7" primary="false" name="Loyalist"/>
-            <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="f600-3c51-d8fd-c9e8" primary="false" name="White Scars"/>
-          </categoryLinks>
           <profiles>
             <profile name="Hibou Khan" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="b074-b4c8-a8b7-2137" publicationId="b905-0414-1057-bb34">
               <characteristics>
@@ -550,9 +532,11 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <infoLink name="[Legiones Astartes]" id="dedd-3763-3ba1-7737" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink targetId="6dbf-654a-f06f-2d69" id="bdc7-4b15-527b-695a" primary="true" name="Command"/>
-        <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="8bbb-e59c-15cb-c3cc" primary="false" name="White Scars"/>
         <categoryLink targetId="4381-ed35-c3fa-a225" id="68c2-7db5-2557-efe2" primary="false" name="Loyalist"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="e76d-0164-a36d-3d8b" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="6f81-0427-dabc-e7e7" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="5151-dbbb-2533-df70" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="901a-6b71-7a29-4597" id="ab28-8c69-d391-0a96" primary="false" name="Officer of the Line (2)"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -651,10 +635,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="3ebf-3529-8763-7777" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="a073-2d4a-5bed-123e" id="7158-5727-7a9a-ba23" primary="true" name="Cavalry Model Type"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Kontos Power Lance" hidden="false" id="d5b6-3335-4113-e8f1" type="selectionEntry" targetId="460b-3b52-f7d1-7d69" sortIndex="1">
               <constraints>
@@ -729,8 +709,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
           </profiles>
           <categoryLinks>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="0892-7538-bf85-e271" primary="false" name="Sergeant Model Sub-Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="b50f-4c5b-2112-8e34" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="a073-2d4a-5bed-123e" id="f33d-2aa6-5cb8-6a98" primary="true" name="Cavalry Model Type"/>
           </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Kontos Power Lance" hidden="false" id="f0a2-af0b-4797-3ef5" type="selectionEntry" targetId="460b-3b52-f7d1-7d69" sortIndex="1">
@@ -799,8 +777,8 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="5d5e-958f-e388-50b5" id="ae68-3b17-4a34-27e6" primary="true" name="Elites"/>
-        <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="9c19-2547-606b-3a60" primary="false" name="White Scars"/>
+        <categoryLink targetId="a073-2d4a-5bed-123e" id="bd37-3079-4f41-0a2f" primary="false" name="Cavalry Model Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="c00f-b1e5-4106-5c54" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ebon Keshig" hidden="false" id="9f57-6829-5ec9-4d69" publicationId="7d63-5df4-c656-52de" sortIndex="6">
@@ -844,9 +822,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
             <constraint type="min" value="5" field="selections" scope="parent" shared="true" id="1d58-0b96-3fb1-de07" includeChildSelections="false"/>
             <constraint type="max" value="10" field="selections" scope="parent" shared="true" id="4d29-b83e-140c-7a52" includeChildSelections="false"/>
           </constraints>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="927e-c68d-0a76-eb81" primary="true" name="Infantry Model Type"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -879,8 +854,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="3235-bd79-e9b1-60fa" id="55d3-bf6e-4fe2-3928" primary="true" name="Heavy Assault"/>
-        <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="c513-6924-3eda-5018" primary="false" name="White Scars"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="85c4-e834-bfb3-41da" primary="false" name="Infantry Model Type"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Kyzagan Assault Speeder" hidden="false" id="6efd-34c7-2212-1474" publicationId="b905-0414-1057-bb34" sortIndex="7">
@@ -933,10 +907,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
               </constraints>
             </entryLink>
           </entryLinks>
-          <categoryLinks>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="c701-6538-bb99-69f0" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="a073-2d4a-5bed-123e" id="38fa-585f-f351-81cb" primary="true" name="Cavalry Model Type"/>
-          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -960,8 +930,8 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <categoryLinks>
-        <categoryLink targetId="345f-9ba6-9b02-ed5c" id="51e2-4728-e3fa-8798" primary="true" name="Support"/>
-        <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="36dd-af73-322b-2c80" primary="false" name="White Scars"/>
+        <categoryLink targetId="a073-2d4a-5bed-123e" id="bc19-b876-7ac3-78f4" primary="false" name="Cavalry Model Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="df54-faa1-c9b9-a04f" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Stormcalling" hidden="false" id="4a7e-871d-36e6-c483">
@@ -1031,7 +1001,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="fa5d-7077-596a-50c7" primary="true" name="Warlord"/>
         <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="5eff-b3c7-fb28-7d06" primary="false" name="White Scars"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="7722-4566-a460-55e5" primary="false" name="Loyalist"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Qin Xa" hidden="false" id="aef2-d55a-ceca-ef8e" type="selectionEntry" targetId="0935-9158-92d0-5528" sortIndex="2">
@@ -1041,7 +1010,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="eef4-89dd-03cd-4903" primary="true" name="High Command"/>
         <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="e0b5-9a97-0834-318e" primary="false" name="White Scars"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="b301-97a8-1723-ca1c" primary="false" name="Loyalist"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Hibou Khan" hidden="false" id="237b-ac58-1954-957e" type="selectionEntry" targetId="fd81-80fc-3d80-5f8b" sortIndex="3">
@@ -1051,7 +1019,6 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="50fe-a0ff-cd68-26d4" primary="true" name="Command"/>
         <categoryLink targetId="ad95-5dc4-7b15-8ff3" id="e4f7-2bcc-930a-6386" primary="false" name="White Scars"/>
-        <categoryLink targetId="4381-ed35-c3fa-a225" id="2c84-0d3a-6f76-f040" primary="false" name="Loyalist"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Stormseer" hidden="false" id="613c-ffd0-7238-a10c" type="selectionEntry" targetId="5123-b5ea-c6dc-7bb9" sortIndex="4">

--- a/Word Bearers.cat
+++ b/Word Bearers.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="4935-1832-63f7-91aa" name="                        XVII - Word Bearers" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="4935-1832-63f7-91aa" name="                        XVII - Word Bearers" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Lorgar Aurelian" hidden="false" id="a763-c205-9fe6-46c1">
       <selectionEntries>
@@ -50,14 +50,6 @@
               <comment>Loyalist</comment>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="7799-e1d6-762b-700b" id="0c46-5b15-4ddf-b858" primary="false" name="Paragon Model Type"/>
-            <categoryLink targetId="b980-187b-2b17-d635" id="cc1a-9a09-5737-4674" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="2162-cf83-67ba-61ec" primary="false" name="Master of the Legion"/>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="0b94-9059-490c-17f5" primary="false" name="Psyker"/>
-            <categoryLink targetId="2aba-8953-ea2f-ce59" id="648e-636b-7753-fd79" primary="false" name="Word Bearers"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="f628-1e25-d1a4-723c" primary="false" name="Traitor"/>
-          </categoryLinks>
           <rules>
             <rule name="The Power of the Word" id="3f98-81ce-1608-51fc" hidden="false">
               <description>A Model with this Special Rule can join Units with the Malefic Sub-Type as if it had that Sub-Type and while part of such a Unit, is treated as having that Sub-Type</description>
@@ -166,6 +158,14 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="25da-7ee0-98a9-2318" primary="false" name="Traitor"/>
+        <categoryLink targetId="7799-e1d6-762b-700b" id="2043-61e8-e24a-5064" primary="false" name="Paragon Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="56a0-bd82-c33a-cce8" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="41e1-fd69-bec2-e59c" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="9e4d-5f75-f346-52ac" primary="false" name="Psyker"/>
+        <categoryLink targetId="8e24-2d8b-26e7-d7aa" id="bbe0-4f97-ebc6-73ed" primary="false" name="Anathemata"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Burning Lore" hidden="false" id="5e68-1411-2656-464f">
       <modifiers>
@@ -239,14 +239,6 @@
             </infoLink>
             <infoLink name="Slow and Purposeful" id="3591-144d-93ca-3b5b" hidden="false" type="rule" targetId="6a8e-e508-abc9-cb3e"/>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="03e8-e62e-962b-8c90" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="e42e-995f-3f52-6637" primary="false" name="Master of the Legion"/>
-            <categoryLink targetId="2aba-8953-ea2f-ce59" id="32da-85ec-50ba-57fb" primary="false" name="Word Bearers"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="6a6e-d24e-ad5b-ca7f" primary="false" name="Traitor"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="fdf7-0191-68dd-8105" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="c888-b2af-8551-a2b2" primary="false" name="Command Model Sub-type"/>
-          </categoryLinks>
           <rules>
             <rule name="Dark Oratory" id="898b-36fe-df6b-50a3" hidden="false">
               <description>A Model with this Special Rule can join Units with the Malefic Sub-Type as if it had that Sub-Type and while part of such a Unit, is treated as having that Sub-Type</description>
@@ -326,6 +318,13 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="b501-b780-209a-cbcd" primary="false" name="Traitor"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="540a-65e4-ab00-1225" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="fb82-82a7-1112-dfad" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="f333-154c-9ca8-f199" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="4562-0417-57ff-5c91" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Erebus" hidden="false" id="f075-69f8-c356-a63a">
       <selectionEntries>
@@ -370,14 +369,6 @@
           <infoLinks>
             <infoLink name="Unwavering Conviction" id="6bca-f09a-0426-381e" hidden="false" type="rule" targetId="fe99-0874-2c10-cba5"/>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="d7a2-13a2-58af-e8ba" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="e2c7-cd79-3b58-a9b1" primary="false" name="Psyker"/>
-            <categoryLink targetId="2aba-8953-ea2f-ce59" id="908f-c171-a17d-78ae" primary="false" name="Word Bearers"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="9e88-89f9-5e5b-4087" primary="false" name="Traitor"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="c215-a0de-9052-c680" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="2a12-78e5-a0e1-a518" primary="false" name="Command Model Sub-type"/>
-          </categoryLinks>
           <rules>
             <rule name="Lord of the Blessed" id="ee53-dde6-9800-a3b9" hidden="false">
               <description>A Model with this Special Rule can join Units with the Malefic Sub-Type as if it had that Sub-Type and while part of such a Unit, is treated as having that Sub-Type.</description>
@@ -453,6 +444,14 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="ad98-d84e-d344-7475" primary="false" name="Traitor"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="71ac-f6e4-70a1-203a" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="5654-d2d8-b0a1-6b30" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="67f4-6680-c2a7-1a25" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="9254-b1e9-98b2-6101" id="012f-6848-fea0-64f1" primary="false" name="Psyker"/>
+        <categoryLink targetId="8e24-2d8b-26e7-d7aa" id="b474-3d31-f289-5ff2" primary="false" name="Anathemata"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Arget Tal" hidden="false" id="185b-76ba-116a-7ad7">
       <selectionEntries>
@@ -504,16 +503,6 @@
               <comment>5+</comment>
             </infoLink>
           </infoLinks>
-          <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="5c14-d45e-0edf-5bd9" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="1794-d25a-f8d0-c40f" primary="false" name="Master of the Legion"/>
-            <categoryLink targetId="2aba-8953-ea2f-ce59" id="8755-8f5e-df89-b56c" primary="false" name="Word Bearers"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="5238-de5c-19a5-5891" primary="false" name="Traitor"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="64a7-5818-dd1f-1a37" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="e8c7-10e2-323f-7f62" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="aec2-6526-e425-2f72" primary="false" name="Antigrav Model Sub-Type"/>
-            <categoryLink targetId="2de1-ddd6-ebb4-10df" id="07c3-5120-2509-e250" primary="false" name="Malefic"/>
-          </categoryLinks>
           <entryLinks>
             <entryLink import="true" name="Burning Lore" hidden="false" id="3454-6429-2731-f567" type="selectionEntry" targetId="5e68-1411-2656-464f" sortIndex="4">
               <constraints>
@@ -569,6 +558,15 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="cc76-1d0c-eec4-0862" primary="false" name="Traitor"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="49c4-8d39-4ce7-f57d" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="b980-187b-2b17-d635" id="d3c2-9cf0-2910-f1e9" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="9871-cb62-5283-2216" id="c8a6-9c10-ec78-377b" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="8ab7-c0a6-cc6b-0e2c" primary="false" name="Antigrav Model Sub-Type"/>
+        <categoryLink targetId="2de1-ddd6-ebb4-10df" id="0c70-5eb8-230f-cbed" primary="false" name="Malefic"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="3786-6770-2991-b84a" primary="false" name="Master of the Legion"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Zardu Layak" hidden="false" id="dab8-484b-f682-a29d">
       <selectionEntries>
@@ -631,13 +629,9 @@
             <infoLink name="Breach the Veil" id="fd29-0fd6-dfc1-656e" hidden="false" type="profile" targetId="0e6b-31ce-26ee-f05e"/>
           </infoLinks>
           <categoryLinks>
-            <categoryLink targetId="b980-187b-2b17-d635" id="ee0e-b174-175f-f2ed" primary="false" name="Unique Model Sub-Type"/>
-            <categoryLink targetId="2aba-8953-ea2f-ce59" id="962e-bb1b-f893-ef97" primary="false" name="Word Bearers"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="218b-d8b1-01f8-4837" primary="false" name="Traitor"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="74bc-f749-02c0-7968" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="9871-cb62-5283-2216" id="1194-f82d-0168-c8c7" primary="false" name="Command Model Sub-type"/>
-            <categoryLink targetId="2de1-ddd6-ebb4-10df" id="8ef7-b897-517b-f457" primary="false" name="Malefic"/>
-            <categoryLink targetId="9254-b1e9-98b2-6101" id="e0d1-5b1b-ad73-512e" primary="false" name="Psyker"/>
+            <categoryLink targetId="9871-cb62-5283-2216" id="b692-2aad-add1-7bbf" primary="false" name="Command Model Sub-type"/>
+            <categoryLink targetId="b980-187b-2b17-d635" id="acaf-6553-2475-45d8" primary="false" name="Unique Model Sub-Type"/>
+            <categoryLink targetId="9254-b1e9-98b2-6101" id="c8b7-d0e8-0538-fd5b" primary="false" name="Psyker"/>
           </categoryLinks>
           <rules>
             <rule name="Binder of Souls" id="0795-59f5-4d5e-d30b" hidden="false"/>
@@ -768,10 +762,7 @@
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="9dac-9557-1c79-7c13" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="5a95-e564-96b2-8dc9" id="336a-4494-4287-40cb" primary="false" name="Champion Model Sub-Type"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="45d1-4d6b-13ac-ecc1" primary="false" name="Traitor"/>
-            <categoryLink targetId="2aba-8953-ea2f-ce59" id="d4dc-37b1-4c05-e014" primary="false" name="Word Bearers"/>
           </categoryLinks>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Anakatis blade " hidden="false" id="60d5-923f-cade-4bcf">
@@ -822,6 +813,11 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="c8f9-9c6c-c672-cbf5" primary="false" name="Traitor"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="fbef-6ae5-5e0f-cc87" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="2de1-ddd6-ebb4-10df" id="aabb-99fa-8233-0415" primary="false" name="Malefic"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Gal Vorbak" hidden="false" id="bb3e-f926-23ec-c561">
       <selectionEntries>
@@ -877,11 +873,6 @@
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="5495-6790-8bb0-98ad" primary="false" name="Traitor"/>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="ef9d-2d1f-7e96-0504" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="2de1-ddd6-ebb4-10df" id="2570-6023-4abf-be1a" primary="false" name="Malefic"/>
-          </categoryLinks>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Tainted Talons" hidden="false" id="f75d-72d3-79c2-ba3b">
               <constraints>
@@ -959,6 +950,11 @@
           </conditions>
         </modifier>
       </modifiers>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="af04-8d89-91fc-1a68" primary="false" name="Traitor"/>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="abcb-2802-543a-7eca" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="2de1-ddd6-ebb4-10df" id="3464-0b43-55ee-64be" primary="false" name="Malefic"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Mhara Gal Dreadnought" hidden="false" id="87ac-c2df-6bd9-33e3">
       <selectionEntries>
@@ -988,11 +984,6 @@
               </characteristics>
             </profile>
           </profiles>
-          <categoryLinks>
-            <categoryLink targetId="2de1-ddd6-ebb4-10df" id="348a-3929-42da-4b1d" primary="false" name="Malefic"/>
-            <categoryLink targetId="38d4-d720-8009-acd3" id="22fd-fc6b-0b8a-a3f9" primary="false" name="Walker Model Type"/>
-            <categoryLink targetId="d251-944b-3c3b-0579" id="2064-8678-66a0-6024" primary="false" name="Traitor"/>
-          </categoryLinks>
           <infoLinks>
             <infoLink name="Bulky (X)" id="309b-9999-0aa3-f80f" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
               <modifiers>
@@ -1140,6 +1131,11 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="cd17-3bdd-60e8-fcf0" primary="false" name="Traitor"/>
+        <categoryLink targetId="38d4-d720-8009-acd3" id="bed2-302b-f613-261d" primary="false" name="Walker Model Type"/>
+        <categoryLink targetId="2de1-ddd6-ebb4-10df" id="9d1b-78b0-3230-548f" primary="false" name="Malefic"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Ashen Circle" hidden="false" id="9290-f8f4-ff78-b09c">
       <selectionEntries>
@@ -1181,10 +1177,6 @@
               </constraints>
             </entryLink>
           </entryLinks>
-          <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="e99a-e860-9d05-668b" primary="false" name="Infantry Model Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="e54f-d288-0cdc-8e63" primary="false" name="Antigrav Model Sub-Type"/>
-          </categoryLinks>
           <costs>
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
@@ -1237,9 +1229,7 @@
             </entryLink>
           </entryLinks>
           <categoryLinks>
-            <categoryLink targetId="594d-fa82-13cb-a345" id="1119-afb2-4c53-3153" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="8045-89a4-76d4-fcef" id="4722-1e14-4926-17a5" primary="false" name="Sergeant Model Sub-Type"/>
-            <categoryLink targetId="c504-9dfa-35d3-c98f" id="414b-49cd-0f79-87b1" primary="false" name="Antigrav Model Sub-Type"/>
           </categoryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="The Iconoclast exchanged its Akkadic hand flamer:" id="ff8a-17b4-3124-b75b" hidden="false" defaultSelectionEntryId="04d0-1f99-ce32-94fc" sortIndex="1">
@@ -1297,6 +1287,10 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="594d-fa82-13cb-a345" id="6380-82f1-a11a-2d45" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="c504-9dfa-35d3-c98f" id="0a47-d11a-559a-7777" primary="false" name="Antigrav Model Sub-Type"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Akkadic hand flamer" hidden="false" id="04d0-1f99-ce32-94fc">
       <profiles>
@@ -1417,41 +1411,49 @@
     <entryLink import="true" name="Lorgar Aurelian" hidden="false" id="3f74-fcee-ebe7-6daf" type="selectionEntry" targetId="a763-c205-9fe6-46c1">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="7c94-e383-da06-d875" primary="true" name="Warlord"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="06b1-afe6-d510-3455" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Arget Tal" hidden="false" id="cc58-0f99-610e-0426" type="selectionEntry" targetId="185b-76ba-116a-7ad7">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="c016-b1d7-705e-e0fa" primary="true" name="High Command"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="cfd0-f98f-a4f3-7d36" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Gal Vorbak" hidden="false" id="d374-0470-7755-e9b7" type="selectionEntry" targetId="bb3e-f926-23ec-c561">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="4df1-64b7-5ad0-06a1" primary="true" name="Elites"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="13aa-635d-e76f-54ca" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Erebus" hidden="false" id="abf5-e9e8-7a90-2e2f" type="selectionEntry" targetId="f075-69f8-c356-a63a">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="6d6f-7507-756b-4fce" primary="true" name="High Command"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="c22f-4946-dea0-f8f3" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Kor Phaeron " hidden="false" id="b77c-5d9b-e8f0-fdfd" type="selectionEntry" targetId="81d5-3d0d-6447-d52b">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="797a-b93e-9f42-b310" primary="true" name="High Command"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="8c7a-210e-6ecd-c17a" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Zardu Layak" hidden="false" id="634b-4492-dc6f-d829" type="selectionEntry" targetId="dab8-484b-f682-a29d">
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="93ac-87ef-9c4b-e3ce" primary="true" name="Command"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="11b9-7296-8b52-c3ba" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Ashen Circle" hidden="false" id="4f05-5ff4-f414-18f4" type="selectionEntry" targetId="9290-f8f4-ff78-b09c">
       <categoryLinks>
         <categoryLink targetId="cf96-8891-3f9a-8921" id="9907-3fa5-0848-3f38" primary="true" name="Fast Attack"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="2288-bd04-6e30-723c" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Mhara Gal Dreadnought" hidden="false" id="9003-7fc9-5a92-81a4" type="selectionEntry" targetId="87ac-c2df-6bd9-33e3">
       <categoryLinks>
         <categoryLink targetId="2499-7239-685f-8465" id="c0e0-eb4e-9a6e-1737" primary="true" name="War-engine"/>
+        <categoryLink targetId="2aba-8953-ea2f-ce59" id="b1b9-d6eb-557c-b693" primary="false" name="Word Bearers"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/World Eaters.cat
+++ b/World Eaters.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="a956-190d-3b47-6258" name="                        XII - World Eaters" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="6" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="a956-190d-3b47-6258" name="                        XII - World Eaters" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="7" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Angron" hidden="false" id="af62-d4a0-c800-712e">
       <selectionEntries>
@@ -145,6 +145,8 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
       <categoryLinks>
         <categoryLink targetId="7799-e1d6-762b-700b" id="270b-06a9-0360-6441" primary="false" name="Paragon Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="ef57-07f8-f508-09fc" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="57b5-7cb8-4b1c-8e17" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="8333-26d1-85ed-c5a7" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="450"/>
@@ -460,6 +462,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
       <categoryLinks>
         <categoryLink targetId="1e7d-9066-28d2-97a0" id="09da-4735-b341-b040" primary="false" name="Heavy Model Sub-Type"/>
         <categoryLink targetId="594d-fa82-13cb-a345" id="d06f-0282-ad04-d361" primary="false" name="Infantry Model Type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="aa03-637b-927d-9792" primary="false" name="Traitor"/>
       </categoryLinks>
       <rules>
         <rule name="Ravening Madmen" id="a4e1-579c-4599-cfaa" hidden="false">
@@ -515,6 +518,7 @@ Any Hit Tests made in the Assault Phase that target a Unit that includes one or 
         <categoryLink targetId="8045-89a4-76d4-fcef" id="7bfd-f836-df32-fad9" primary="false" name="Sergeant Model Sub-Type"/>
         <categoryLink targetId="af7d-af64-6b7d-da9d" id="c9b7-59a4-33fd-9293" primary="false" name="Specialist Model Sub-Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="f27a-3949-bb3b-64f6" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="4f5d-e1e8-f2b5-c06b" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="85"/>
@@ -675,6 +679,8 @@ If a Unit includes a Model with this Special Rule, during the Start Phase of the
         <categoryLink targetId="c504-9dfa-35d3-c98f" id="1ea7-cfa8-1de9-7c41" primary="false" name="Antigrav Model Sub-Type"/>
         <categoryLink targetId="2de1-ddd6-ebb4-10df" id="2659-cdc6-2a46-fecc" primary="false" name="Malefic"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="f105-125d-fa16-8c3e" primary="false" name="Unique Model Sub-Type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="239a-8628-d59a-53ff" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="fdb1-14d9-5bad-6291" primary="false" name="Traitor"/>
       </categoryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="95ec-bb63-a37c-bfba" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -788,6 +794,8 @@ If a Unit includes a Model with this Special Rule, during the Start Phase of the
         <categoryLink targetId="594d-fa82-13cb-a345" id="15cb-892a-687b-bc7b" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="b980-187b-2b17-d635" id="47d4-b06e-537f-1b9d" primary="false" name="Unique Model Sub-Type"/>
         <categoryLink targetId="9871-cb62-5283-2216" id="095b-37a9-d949-e528" primary="false" name="Command Model Sub-type"/>
+        <categoryLink targetId="e3cd-7a38-34d7-9cbf" id="a660-5ba7-2fb3-6486" primary="false" name="Master of the Legion"/>
+        <categoryLink targetId="d251-944b-3c3b-0579" id="6996-ff05-0689-5e40" primary="false" name="Traitor"/>
       </categoryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="175"/>
@@ -1231,11 +1239,13 @@ On any Turn in which they made a Charge Move, Models with this Special Rule modi
     <entryLink import="true" name="Angron" hidden="false" id="2385-2519-105f-fc50" type="selectionEntry" targetId="af62-d4a0-c800-712e">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="f18e-f7d2-3c90-64ca" primary="true" name="Warlord"/>
+        <categoryLink targetId="48b7-17a8-eaf4-d6c2" id="1f8a-6c5e-c56c-a91c" primary="false" name="World Eaters"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Rampager Squad" hidden="false" id="6ab4-9770-dcb2-8b0b" type="selectionEntry" targetId="c660-c7ad-70b0-5318">
       <categoryLinks>
         <categoryLink targetId="3235-bd79-e9b1-60fa" id="1e40-c776-4d95-3799" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="48b7-17a8-eaf4-d6c2" id="1f2a-cf56-a840-7488" primary="false" name="World Eaters"/>
       </categoryLinks>
       <modifiers>
         <modifier type="set-primary" value="91f0-1b91-0a9a-c542" field="category">
@@ -1248,21 +1258,25 @@ On any Turn in which they made a Charge Move, Models with this Special Rule modi
     <entryLink import="true" name="Red Butchers" hidden="false" id="542f-ad6f-ca67-8e34" type="selectionEntry" targetId="e149-7a3c-d62c-e941">
       <categoryLinks>
         <categoryLink targetId="5d5e-958f-e388-50b5" id="1c2f-c622-90a0-13f9" primary="true" name="Elites"/>
+        <categoryLink targetId="48b7-17a8-eaf4-d6c2" id="1957-4e1d-730a-950a" primary="false" name="World Eaters"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Angron Transfigured" hidden="false" id="ccc1-bba6-cf7c-cfa8" type="selectionEntry" targetId="eb31-de9c-e5ef-a9ac">
       <categoryLinks>
         <categoryLink targetId="22ee-7208-4089-b005" id="8261-7fd3-5c9a-59d6" primary="true" name="Warlord"/>
+        <categoryLink targetId="48b7-17a8-eaf4-d6c2" id="b22b-24f6-a63f-e035" primary="false" name="World Eaters"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Lotara Sarrin" hidden="false" id="cfd9-ce39-c208-7dc0" type="selectionEntry" targetId="e628-409b-5f93-170a">
       <categoryLinks>
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="b94d-d8dc-424f-0be9" primary="true" name="Command"/>
+        <categoryLink targetId="48b7-17a8-eaf4-d6c2" id="fd27-9376-ae0d-6cf7" primary="false" name="World Eaters"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Kharn the Bloody" hidden="false" id="e0d5-8405-aba7-628b" type="selectionEntry" targetId="19c9-b57d-a308-b655">
       <categoryLinks>
         <categoryLink targetId="d9a6-9b5f-b18a-4d63" id="769c-7d94-776c-0445" primary="true" name="High Command"/>
+        <categoryLink targetId="48b7-17a8-eaf4-d6c2" id="3aaa-525a-8e73-09fb" primary="false" name="World Eaters"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Rite of War" hidden="false" id="1ce9-43c5-ef27-ef7f" type="selectionEntry" targetId="0797-1862-f00c-9f92">


### PR DESCRIPTION
Lots of categories were mismatched all over the legions. This also caused issues to AL in RoT as it was counting units as both a RoT and their normal primary slot.

Also corrected Konrad Curze to the correct spelling.