### PR TITLE
More tests and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,19 +42,32 @@ Copy what is printed in the books.
 - If the book has something as Upper Upper, eg "Legion Officer Wargear" then capitalise every word.
 - If the book does not capitalise something, eg "Any model may exchange their *bolter*..." then it does not need to be capitalised unless it is the first owrd in a string/sentence/label.
 
-# 3: Default Inclusions on Units
-## 3.1: Astartes Units
+# 3: Making Units
+All units should be made as shared selection entries
+
+Then each unit should have a link to that shared selection entry in its catalogue.
+For the legions, they import the root selection entries from the LA cat. 
+
+## 3.1: Default Inclusions on Units
+
+Each link should have the battlefield role on the force org slot. [x] Checked by the unit tests
+
+###  Astartes Units
 All Astartes units should have the following Traits at the root level of the unit (Add Link -> Profile -> Search for them):
 - \[Allegiance]
 - \[Legiones Astartes]
-## Mechanicum Units
+
+The legion specific units should not have the legion trait category set on the shared selection entry, 
+and instead it should be set on the link. This is so alpha legion can import them without this trait [x] These are the only traits allowed other than the battlefield roles by the unit tests.
+
+### Mechanicum Units
 All Mechanicum units should have the following Traits at the root level of the unit (Add Link -> Profile -> Search for them):
 - \[Allegiance]
-## Solar Auxilia Units
+### Solar Auxilia Units
 All Auxilia units should have the following Traits at the root level of the unit (Add Link -> Profile -> Search for them):
 - \[Allegiance]
 -  Solar Auxilia
-## Questoris Household Units
+### Questoris Household Units
 All Auxilia units should have the following Traits at the root level of the unit (Add Link -> Profile -> Search for them):
 - \[Allegiance]
 

--- a/Talons of the Emperor.cat
+++ b/Talons of the Emperor.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="acc1-f897-a117-9b4a" name="Legio Custodes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="4" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="acc1-f897-a117-9b4a" name="Legio Custodes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="5" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Constantin Valdor" hidden="false" id="9cbb-0abc-5c93-2afd">
       <selectionEntries>
@@ -3012,13 +3012,11 @@ In the Victory Sub-Phase of any End Phase, when a Unit with at least one Model 
     </entryLink>
     <entryLink import="true" name="Orion Assault Dropship" hidden="false" id="baae-c2d4-3028-7c1c" type="selectionEntry" targetId="0c29-b45c-d6e4-6a18">
       <categoryLinks>
-        <categoryLink targetId="88e6-d373-4152-0dd8" id="aaff-1423-ac91-cb56" primary="false" name="Troops"/>
         <categoryLink targetId="a46f-a465-0ead-d6b8" id="5b46-6027-c9eb-5060" primary="true" name="Lord of War"/>
       </categoryLinks>
     </entryLink>
     <entryLink import="true" name="Ares Gunship" hidden="false" id="c5e2-c9ab-a62d-2c5f" type="selectionEntry" targetId="0c44-ab22-006f-ebf3">
       <categoryLinks>
-        <categoryLink targetId="88e6-d373-4152-0dd8" id="976d-0087-92f3-0ecf" primary="false" name="Troops"/>
         <categoryLink targetId="a46f-a465-0ead-d6b8" id="4663-d0bb-f257-4f77" primary="true" name="Lord of War"/>
       </categoryLinks>
     </entryLink>

--- a/tests/validatehh3.py
+++ b/tests/validatehh3.py
@@ -21,6 +21,7 @@ class GameTests(unittest.TestCase):
     def test_root_link_categories(self):
         expected_primaries = Heresy3e.BATTLEFIELD_ROLES.copy()
         expected_primaries += ['Army Configuration', 'Rewards of Treachery']
+        expected_secondaries = Heresy3e.FACTIONS.copy()
         for file in self.system.files:
             entry_links_node = file.root_node.get_child(tag='entryLinks')
             if entry_links_node is None:
@@ -35,6 +36,12 @@ class GameTests(unittest.TestCase):
                     self.assertIn(primary_cat.target_name, expected_primaries,
                                   f"(The link's primary category) is a battlefield role: "
                                   )
+                    for other_link in category_links.children:
+                        if other_link.id == primary_cat.id:
+                            continue  # Skip the primary we've already checked.
+                        self.assertIn(other_link.target_name, expected_secondaries,
+                                      f"(The link's primary category) is a faction: "
+                                      )
 
     if __name__ == '__main__':
         unittest.main()

--- a/tests/validatehh3.py
+++ b/tests/validatehh3.py
@@ -43,5 +43,5 @@ class GameTests(unittest.TestCase):
                                       f"(The link's primary category) is a faction: "
                                       )
 
-    if __name__ == '__main__':
-        unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/validatehh3.py
+++ b/tests/validatehh3.py
@@ -5,6 +5,8 @@ import unittest
 # Temp until we have a pip module
 sys.path.insert(1, os.getcwd() + "/BSCopy")
 from BSCopy.system.system import System
+from BSCopy.system.constants import SystemSettingsKeys, GameImportSpecs
+from BSCopy.system.game.heresy3e import Heresy3e
 
 
 class GameTests(unittest.TestCase):
@@ -12,25 +14,27 @@ class GameTests(unittest.TestCase):
     def setUp(self):
         self.system = System('horus-heresy-3rd-edition',
                              settings={
-                                 # SystemSettingsKeys.GAME_IMPORT_SPEC: GameImportSpecs.HERESY3E,
+                                 SystemSettingsKeys.GAME_IMPORT_SPEC: GameImportSpecs.HERESY3E,
                              },
                              )
 
-    def test_all_root_links_1_category(self):
+    def test_root_link_categories(self):
+        expected_primaries = Heresy3e.BATTLEFIELD_ROLES.copy()
+        expected_primaries += ['Army Configuration', 'Rewards of Treachery']
         for file in self.system.files:
             entry_links_node = file.root_node.get_child(tag='entryLinks')
             if entry_links_node is None:
                 continue
             for child in entry_links_node.children:
-                category_count = len(child.get_categories())
-                with self.subTest(f"There should be 1 category defined on root link {child}"):
-                    self.assertEqual(category_count, 1,
-                                     f"Found {category_count}"
-                                     )
-                if category_count == 1:
-                    link = child.get_child(tag='categoryLink')
-                    pass  # TODO: Check that it's primary
+                with self.subTest(f"Root link {child}'s primary category should be a battlefield role"):
+                    category_links = child.get_child(tag='categoryLinks')
+                    primary_cat = category_links.get_child(tag='categoryLink', attrib={"primary": "true"})
+                    self.assertIsNotNone(primary_cat,
+                                         f"There should be a primary category"
+                                         )
+                    self.assertIn(primary_cat.target_name, expected_primaries,
+                                  f"(The link's primary category) is a battlefield role: "
+                                  )
 
-
-if __name__ == '__main__':
-    unittest.main()
+    if __name__ == '__main__':
+        unittest.main()


### PR DESCRIPTION
I've updated the tests and readme as below. @The4D6 does this sound good? Please let me know if you want any changes.

# 3: Making Units
All units should be made as shared selection entries

Then each unit should have a link to that shared selection entry in its catalogue.
For the legions, they import the root selection entries from the LA cat. 

## 3.1: Default Inclusions on Units

Each link should have the battlefield role on the force org slot. [x] Checked by the unit tests

###  Astartes Units
All Astartes units should have the following Traits at the root level of the unit (Add Link -> Profile -> Search for them):
- \[Allegiance]
- \[Legiones Astartes]

The legion specific units should not have the legion trait category set on the shared selection entry, 
and instead it should be set on the link. This is so alpha legion can import them without this trait [x] These are the only traits allowed other than the battlefield roles by the unit tests.
