### PR TITLE
Update Legiones Astartes with Prime Benefits for 4 legions

### DIFF
--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -4805,7 +4805,7 @@
         <forceEntry name="Auxiliary - Veletaris Tercio" id="e1a1-2699-4681-47ab" hidden="true" sortIndex="30">
           <categoryLinks>
             <categoryLink name="Auxiliary Detachment" hidden="false" id="55a1-8512-405b-8905" targetId="1a65-8b23-419b-b30f"/>
-            <categoryLink name="Elites - Veletaris Storm or Veletaris Vanguard units only" hidden="false" id="710a-9bde-a37e-3661" targetId="8dce-eb64-ec33-0b51" type="categoryEntry">
+            <categoryLink name="Elites - Veletaris Storm or Veletaris Vanguard units only" hidden="false" id="710a-9bde-a37e-3661" targetId="8dce-eb64-ec33-0b51">
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="0cbe-df78-5aa1-886c"/>
               </constraints>
@@ -4817,7 +4817,7 @@
                 </modifier>
               </modifiers>
             </categoryLink>
-            <categoryLink name="Support - Hermes Veletaris units only" hidden="false" id="3821-2b49-3d7e-6f18" targetId="c480-7340-9da9-d9ac" type="categoryEntry">
+            <categoryLink name="Support - Hermes Veletaris units only" hidden="false" id="3821-2b49-3d7e-6f18" targetId="c480-7340-9da9-d9ac">
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0fc4-b367-183f-a2cc"/>
               </constraints>
@@ -5008,7 +5008,7 @@
                 </modifier>
               </modifiers>
             </categoryLink>
-            <categoryLink name="Troops" hidden="false" id="c12d-2c85-a227-0b86" targetId="88e6-d373-4152-0dd8" type="categoryEntry">
+            <categoryLink name="Troops" hidden="false" id="c12d-2c85-a227-0b86" targetId="88e6-d373-4152-0dd8">
               <modifiers>
                 <modifier type="increment" value="1" field="aa68-7c65-5d9f-280f">
                   <conditions>
@@ -5063,7 +5063,7 @@
         <forceEntry name="Auxiliary - Armour Tercio" id="6aff-b91d-02bb-7461" hidden="true" sortIndex="31">
           <categoryLinks>
             <categoryLink name="Auxiliary Detachment" hidden="false" id="880f-e609-7151-ee38" targetId="1a65-8b23-419b-b30f"/>
-            <categoryLink name="Armour - Leman Russ Strike, Leman Russ Assault or Malcador Heavy tank units only" hidden="false" id="0bee-0d7e-0466-e2cb" targetId="5725-7f8c-f02e-4df6" type="categoryEntry">
+            <categoryLink name="Armour - Leman Russ Strike, Leman Russ Assault or Malcador Heavy tank units only" hidden="false" id="0bee-0d7e-0466-e2cb" targetId="5725-7f8c-f02e-4df6">
               <constraints>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="e63e-7101-ee0c-825b"/>
               </constraints>
@@ -5116,7 +5116,7 @@
                 <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="69ec-fb9b-4ad6-bf96" includeChildSelections="true"/>
               </constraints>
             </categoryLink>
-            <categoryLink name="Support - Rapier Section, Basilisk Artillery Tank or Medusa Artillery tank units only" hidden="false" id="9be5-2fdf-195d-448c" targetId="ada1-aac4-9802-9c3d" type="categoryEntry">
+            <categoryLink name="Support - Rapier Section, Basilisk Artillery Tank or Medusa Artillery tank units only" hidden="false" id="9be5-2fdf-195d-448c" targetId="ada1-aac4-9802-9c3d">
               <constraints>
                 <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="3a15-2aaa-7be7-b63e"/>
               </constraints>
@@ -5164,7 +5164,7 @@
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d3ab-da50-e5e0-666c" includeChildSelections="true"/>
               </constraints>
             </categoryLink>
-            <categoryLink name="Troops - Lasrifle Section Units only" hidden="false" id="5b44-72e9-776a-c15c" targetId="f006-dd7c-6753-f732" type="categoryEntry">
+            <categoryLink name="Troops - Lasrifle Section Units only" hidden="false" id="5b44-72e9-776a-c15c" targetId="f006-dd7c-6753-f732">
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="9b47-a597-d110-0bf2" includeChildSelections="false"/>
               </constraints>
@@ -5176,7 +5176,7 @@
                 </modifier>
               </modifiers>
             </categoryLink>
-            <categoryLink name="Recon - Hermes Light Sentinel Squadron units only" hidden="false" id="594e-63ee-a073-3fb5" targetId="b367-e724-5450-9e45" type="categoryEntry">
+            <categoryLink name="Recon - Hermes Light Sentinel Squadron units only" hidden="false" id="594e-63ee-a073-3fb5" targetId="b367-e724-5450-9e45">
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7cc3-afb1-35ca-ebac"/>
               </constraints>
@@ -5408,12 +5408,12 @@
         <forceEntry name="Auxiliary - Scout Tercio" id="551a-23a1-7758-2688" hidden="true" sortIndex="34">
           <categoryLinks>
             <categoryLink name="Auxiliary Detachment" hidden="false" id="7fc3-b32d-cdda-e42f" targetId="1a65-8b23-419b-b30f"/>
-            <categoryLink name="Recon - Hermes Light Sentinel Squadron units only" hidden="false" id="4b81-7b2e-792e-003a" targetId="b367-e724-5450-9e45" type="categoryEntry">
+            <categoryLink name="Recon - Hermes Light Sentinel Squadron units only" hidden="false" id="4b81-7b2e-792e-003a" targetId="b367-e724-5450-9e45">
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="a2d1-1899-30ed-b88f"/>
               </constraints>
             </categoryLink>
-            <categoryLink name="War-engine - Aethon Heavy Sentinel Squadron units only" hidden="false" id="9caf-684c-aa64-c23c" targetId="5ee3-236d-c224-67aa" type="categoryEntry">
+            <categoryLink name="War-engine - Aethon Heavy Sentinel Squadron units only" hidden="false" id="9caf-684c-aa64-c23c" targetId="5ee3-236d-c224-67aa">
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="744f-12da-093f-e8db"/>
               </constraints>
@@ -12650,6 +12650,13 @@ Please don&apos;t submit bug reports for any of these things. Please only submit
               <description>All Models in the Unit selected to fill the Prime Slot gain a bonus of +1 to their Leadership, Cool, Intelligence and Willpower Characteristics to a maximum of 10 (this includes only Models selected as part of the Unit, not Models that later join the Unit either before or during Battle).</description>
             </rule>
           </rules>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="b980-187b-2b17-d635" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Special Assignment" hidden="false" id="c857-47bd-6a4f-fcf8" sortIndex="4">
           <constraints>
@@ -12664,6 +12671,13 @@ Please don&apos;t submit bug reports for any of these things. Please only submit
               <description>This Prime Advantage may only be selected for a Command Slot. A Command Slot for which this Prime Advantage is selected may be filled by a High Command Unit, but remains a Command Slot. Moreover, no additional Detachment of any kind may be selected due to this Slot regardless of their Battlefield Role or any Special Rule that the Unit selected to fill the Slot may have.</description>
             </rule>
           </rules>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="b980-187b-2b17-d635" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Master Sergeant" hidden="false" id="2c90-1d52-7075-59d3" sortIndex="1">
           <constraints>
@@ -12674,6 +12688,13 @@ Please don&apos;t submit bug reports for any of these things. Please only submit
               <description>One Model in the Unit selected to fill the Prime Slot that has the Sergeant Sub-Type gains +1 to its Attacks, Weapon Skill and Leadership Characteristics and the Champion Sub-Type (if it already has the Champion Sub-Type it instead increases its Leadership by an additional +1). This advantage may only be selected once per Detachment.</description>
             </rule>
           </rules>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="b980-187b-2b17-d635" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Paragon of Battle" hidden="false" id="20cb-4eec-0844-8a97" sortIndex="3">
           <constraints>
@@ -12684,6 +12705,13 @@ Please don&apos;t submit bug reports for any of these things. Please only submit
               <description>One Model in the Unit selected to fill the Prime Slot that has the Command Sub-Type gains a bonus of +1 to its Attacks, Weapon Skill and Ballistic Skill Characteristics.</description>
             </rule>
           </rules>
+          <modifiers>
+            <modifier type="set" value="true" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="b980-187b-2b17-d635" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Logistical Benefit" hidden="false" id="6a03-452b-5657-bda4" sortIndex="5">
           <selectionEntryGroups>

--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="25" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="26" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <categoryEntries>
     <categoryEntry name="Officer of the Line (2)" id="901a-6b71-7a29-4597" hidden="false"/>
     <categoryEntry name="Allegiance" id="c408-52f1-b632-4c82" hidden="false"/>
@@ -268,6 +268,11 @@
     <categoryEntry name="Elites - Seeker Squads or Headhunter Kill Teams Only" id="5c0d-4d49-44e2-0a99" hidden="false"/>
     <categoryEntry name="Cohort Additional Detachment" id="27e8-88b4-d3c8-d63f" hidden="false"/>
     <categoryEntry name="Medusan Vanguard Unlock" id="fc09-911b-ee8c-7967" hidden="true"/>
+    <categoryEntry name="Tartaros Centurion" id="86d7-7e47-a0d7-6041" hidden="false">
+      <comment>Emperors Children prime check</comment>
+    </categoryEntry>
+    <categoryEntry name="Jump Pack Centurion" id="294e-d64c-39dc-f687" hidden="false"/>
+    <categoryEntry name="Cataphractii Centurion" id="fdce-834f-ead1-31c3" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry name="Crusade Force Organization Chart" id="8562-592c-8d4b-a1f0" hidden="false" childForcesLabel="Detachments" sortIndex="1">

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="20" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="21" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>
@@ -14392,6 +14392,97 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               </modifiers>
             </infoLink>
           </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Pack Thegn" hidden="true" id="2a84-8986-b83f-6ba8">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2cee-d4a0-b0e9-5345"/>
+          </constraints>
+          <rules>
+            <rule name="Pack Thegn" id="6f8f-beff-6ab3-36bf" hidden="false">
+              <description>Has it&apos;s Base Attacks and Weapon Skill Characteristics modified by +1
+May have it&apos;s power sword exchanged with one frost sword or frost axe for Free, or with one frost claw for +5 Points</description>
+            </rule>
+          </rules>
+          <comment>Space Wolves</comment>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="d995-cb33-be41-ecf8" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="03f3-e7ae-13b0-47c3" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Chain-bonded" hidden="true" id="bd04-aeac-9dd3-d77a">
+          <rules>
+            <rule name="Chain-brothers" id="35fd-5174-6893-be56" hidden="false">
+              <description>While a Model with this Special Rule is within Unit Coherency of the other Model from your Army with this Special Rule, that Model gains a bonus of +1 to Hit Tests made in the Assault Phase. If a Model that is engaged in a Challenge is in the same Combat as the other Model from your Army with this Special Rule, that Model is treated as being in Unit Coherency  with that other Model for the purposes of this Special Rule.</description>
+            </rule>
+            <rule name="Chain-bonded" id="9fea-f2f7-72b0-919d" hidden="false">
+              <description>This Prime Advantage can only be selected once per Army. When this Prime Advantage is selected, the Controlling Player must select another Unit which only includes Models with the World Eaters Trait that has the Command Battlefield Role from their Army. One Model in the selected Unit and one Model in the Unit selected to fill a Prime Force Organisation Slot with this Prime Advantage both gain the Chain-brothers Special Rule.</description>
+            </rule>
+          </rules>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="force" shared="true" id="6eb4-822a-6b14-5c87" includeChildSelections="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="a956-190d-3b47-6258" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6dbf-654a-f06f-2d69" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <comment>World Eaters</comment>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Atramentar " hidden="true" id="0543-a0b7-e28b-a488">
+          <infoLinks>
+            <infoLink name="Deep Strike" id="7c32-667f-ff79-bad3" hidden="false" type="rule" targetId="0553-d06b-52b9-34db"/>
+            <infoLink name="Impact (X)" id="410b-9bb2-b542-fc38" hidden="false" type="rule" targetId="6ead-c31c-ab09-2f8c">
+              <modifiers>
+                <modifier type="set" value="Impact (I)" field="name"/>
+              </modifiers>
+              <comment>I</comment>
+            </infoLink>
+          </infoLinks>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="486f-b32a-ac87-73dd" shared="true" includeChildSelections="true"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="c795-6de9-030e-e480" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="5dd5-d00c-b150-34b9" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f8c9-8c04-ae18-e7ea" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="bcb4-ccd6-7eb6-0afb" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8105-97e4-8327-c826" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <comment>Night Lords</comment>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="The Iron-clad" hidden="false" id="176e-7ae1-a65d-636c">
+          <rules>
+            <rule name="The Iron-clad" id="1211-b3d7-bebf-2e38" hidden="false">
+              <description>This Prime Advantage can only be selected once per Army. Add one additional War Engine Battlefield Role Slot to the Detachment that includes the Prime Force Organisation Slot with this Prime Advantage. A Unit that is selected to fill that Slot gains the Champion Sub-Type if it did not already have it.</description>
+            </rule>
+          </rules>
+          <comment>Iron Hands</comment>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="2a25-0565-a4af-3cc7" includeChildSelections="true" includeChildForces="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="736e-3967-e72b-e3ac" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6dbf-654a-f06f-2d69" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -522,6 +522,9 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d3d9-b00b-4a4a-5739" includeChildSelections="false"/>
           </constraints>
+          <modifiers>
+            <modifier type="add" value="294e-d64c-39dc-f687" field="category"/>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
       <selectionEntryGroups>
@@ -5052,7 +5055,11 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
       <selectionEntryGroups>
         <selectionEntryGroup name="Terminator Armour" id="babb-6a3c-da26-f5d3" hidden="false" sortIndex="1">
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="2724-c83c-4226-523b"/>
+            <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="2724-c83c-4226-523b">
+              <modifiers>
+                <modifier type="add" value="fdce-834f-ead1-31c3" field="category"/>
+              </modifiers>
+            </selectionEntry>
             <selectionEntry type="upgrade" import="true" name="Tartaros" hidden="false" id="d4a4-a3f7-f634-4632">
               <costs>
                 <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
@@ -15921,9 +15928,10 @@ May have it&apos;s power sword exchanged with one frost sword or frost axe for F
           </modifiers>
           <rules>
             <rule name="Telekine Shift" id="3aa8-e3ad-265b-03c7" hidden="false">
-              <description>When the Controlling Player chooses to make a Rush Move with a Unit made of Models with this Special Rule, they may also choose to make a Willpower Check for that Unit. If the Willpower Check is successful, the Unit gains the Antigrav Sub-Type and the Move Through Cover Special Rule until the end of the current Movement Phase. If the Willpower Check is failed, the selected Unit may not Move during the current Movement Phase. </description>
+              <description>When the Controlling Player chooses to make a Rush Move with a Unit made of Models with this Special Rule, they may also choose to make a Willpower Check for that Unit. If the Willpower Check is successful, the Unit gains the Antigrav Sub-Type and the Move Through Cover Special Rule until the end of the current Movement Phase. If the Willpower Check is failed, the selected Unit may not Move during the current Movement Phase.</description>
             </rule>
           </rules>
+          <comment>Thousand Sons</comment>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="23" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="24" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>
@@ -2531,7 +2531,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="5792-ae2b-89ca-c8e9" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="6bb8-fd9b-2f17-5485" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex=""/>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="6bb8-fd9b-2f17-5485" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="50"/>
@@ -16259,6 +16259,13 @@ May have it&apos;s power sword exchanged with one frost sword or frost axe for F
           </constraints>
         </entryLink>
       </entryLinks>
+      <modifiers>
+        <modifier type="set" value="true" field="hidden">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="b980-187b-2b17-d635" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
     </selectionEntryGroup>
     <selectionEntryGroup name="Prime Benefits" id="a396-b846-c263-6767" hidden="false">
       <entryLinks>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="21" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="22" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>
@@ -462,7 +462,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Centurion" hidden="false" id="6a17-9220-006e-1cab">
+        <selectionEntry type="model" import="true" name="Centurion" hidden="false" id="6a17-9220-006e-1cab" sortIndex="1">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4d7b-e590-91a1-bc28" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0428-a892-801d-2273" includeChildSelections="false"/>
@@ -5017,6 +5017,10 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               </modifiers>
             </profile>
           </profiles>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="037f-e9b7-748f-2387"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d481-ca9f-fac3-600c"/>
+          </constraints>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -5055,6 +5059,9 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
                 <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
               </costs>
+              <modifiers>
+                <modifier type="add" value="86d7-7e47-a0d7-6041" field="category"/>
+              </modifiers>
             </selectionEntry>
           </selectionEntries>
           <constraints>
@@ -14362,7 +14369,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
-        <entryLink import="true" name="Graviton Pistol" hidden="true" id="c14d-e2d8-accd-d52b" type="selectionEntry" targetId="320a-5112-0e89-aad4" sortIndex="5">
+        <entryLink import="true" name="Graviton pistol" hidden="true" id="c14d-e2d8-accd-d52b" type="selectionEntry" targetId="320a-5112-0e89-aad4" sortIndex="5">
           <modifiers>
             <modifier type="set" value="false" field="hidden">
               <conditionGroups>
@@ -15509,6 +15516,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               <conditions>
                 <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="f7b4-2531-0962-1379" shared="true"/>
               </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="594d-fa82-13cb-a345" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="a073-2d4a-5bed-123e" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <categoryLinks>
@@ -15521,6 +15536,10 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               </modifiers>
             </infoLink>
           </infoLinks>
+          <comment>White Scars</comment>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="983f-8e6f-23e4-4086"/>
+          </constraints>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Logisticae" hidden="true" id="907a-ba1b-84ae-b725" publicationId="b905-0414-1057-bb34" page="245">
           <comment>Ultramarines</comment>
@@ -15528,6 +15547,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <modifier type="set" value="false" field="hidden">
               <conditions>
                 <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="656a-07b6-d4fd-57af" shared="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="6dbf-654a-f06f-2d69" shared="true" includeChildSelections="false"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -15535,7 +15555,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="efa6-a5d5-5bb3-8292" includeChildSelections="false"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: gain a trainsport or heavy transport and modify it&apos;s transport capacity by +2" hidden="false" id="26ee-caef-70fd-274b"/>
+            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: gain a trainsport or heavy transport and modify it&apos;s transport capacity by +2" hidden="false" id="26ee-caef-70fd-274b">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="875c-af99-5a2f-bc96"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ced0-7cac-35da-405b"/>
+              </constraints>
+            </selectionEntry>
           </selectionEntries>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Wraiths" hidden="true" id="1e67-d4ea-b59b-b9ff">
@@ -15543,12 +15568,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <modifier type="set" value="false" field="hidden">
               <conditions>
                 <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="340c-1d4f-1f31-fb70" shared="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="88e6-d373-4152-0dd8" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
           <infoLinks>
             <infoLink name="Wraiths" id="bc1b-f834-1d47-0f21" hidden="false" type="rule" targetId="84fd-366e-517d-e228"/>
           </infoLinks>
+          <comment>Raven Guard</comment>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Duty Before Death" hidden="true" id="7d10-f293-cc6d-7aea">
           <modifiers>
@@ -15556,12 +15583,10 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               <conditions>
                 <condition type="instanceOf" value="1" field="selections" scope="force" childId="f148-a6e4-5a8c-3aeb" shared="true" includeChildSelections="true"/>
                 <condition type="instanceOf" value="1" field="selections" scope="force" childId="8f12-c30a-6c20-6296" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="88e6-d373-4152-0dd8" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
-          <entryLinks>
-            <entryLink import="true" name="Duty Before Death" hidden="false" id="3051-a40e-1673-294e" type="rule" targetId="e20b-fd1b-6229-eac2"/>
-          </entryLinks>
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="91b4-9fab-da60-4523"/>
           </constraints>
@@ -15571,7 +15596,9 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <modifier type="set" value="Feel No Pain (6+)" field="name"/>
               </modifiers>
             </infoLink>
+            <infoLink name="Duty Before Death" id="9565-b07b-b9c2-168a" hidden="false" type="rule" targetId="e20b-fd1b-6229-eac2"/>
           </infoLinks>
+          <comment>Salamanders</comment>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Pack Thegn" hidden="true" id="2a84-8986-b83f-6ba8">
           <constraints>
@@ -15592,6 +15619,14 @@ May have it&apos;s power sword exchanged with one frost sword or frost axe for F
               </conditions>
             </modifier>
           </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: Model gains A +1 WS +1 and may exchange power weapon for Frost sword or axe. Frost claw for 5pts." hidden="false" id="b761-e749-c8c4-7600">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="10ec-facb-e7e8-1f78"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ff8d-86c6-24e1-5464"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Chain-bonded" hidden="true" id="bd04-aeac-9dd3-d77a">
           <rules>
@@ -15645,7 +15680,7 @@ May have it&apos;s power sword exchanged with one frost sword or frost axe for F
           </modifiers>
           <comment>Night Lords</comment>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="The Iron-clad" hidden="false" id="176e-7ae1-a65d-636c">
+        <selectionEntry type="upgrade" import="true" name="The Iron-clad" hidden="true" id="176e-7ae1-a65d-636c">
           <rules>
             <rule name="The Iron-clad" id="1211-b3d7-bebf-2e38" hidden="false">
               <description>This Prime Advantage can only be selected once per Army. Add one additional War Engine Battlefield Role Slot to the Detachment that includes the Prime Force Organisation Slot with this Prime Advantage. A Unit that is selected to fill that Slot gains the Champion Sub-Type if it did not already have it.</description>
@@ -15663,6 +15698,232 @@ May have it&apos;s power sword exchanged with one frost sword or frost axe for F
               </conditions>
             </modifier>
           </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: Gain War Engine slot that gives that unit Champion Sub-type" hidden="false" id="940b-b5da-3b26-d03d">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7f4b-64aa-3c20-d6eb"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="471a-1de4-d3f3-ef56"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Paladin of the Hekatonystika" hidden="true" id="b824-c0ad-804e-0026">
+          <comment>Dark Angels</comment>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="0a35-fce3-188c-b3aa" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f613-76c6-e58e-f286" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5fe8-9bf9-3081-b789"/>
+            <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="4e71-0ea3-5d82-156b" includeChildSelections="true" includeChildForces="true"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: WS +1, Bolter exchanged for Terranic Greatsword, Gains Orders of the Hekatonystika." hidden="false" id="6e21-400e-e8cc-e3e5">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="553b-fafa-1f04-27b5"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d4e3-205b-51a8-fd58"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Revenants" hidden="true" id="d5af-128d-2051-644d">
+          <comment>Blood Angels</comment>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7618-c3a3-abaf-5e07"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="9cff-ac34-56ca-260f" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <infoLinks>
+            <infoLink name="Fear (X)" id="6cb9-32a5-2cdf-27ba" hidden="false" type="rule" targetId="0ebc-0c92-2209-6393">
+              <modifiers>
+                <modifier type="set" value="Fear (1)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Castellan" hidden="true" id="da17-ab73-7d33-c76f">
+          <comment>Imperial Fists</comment>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3d33-5534-7020-e485"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="d186-cffc-0950-f632" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f613-76c6-e58e-f286" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: Cannot select any centurion options. Must exchange bolter for Heavy bolter, autocannon, Iliastus assault cannon." hidden="false" id="9517-b0ea-a7ad-959a">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4b06-8748-0e75-1fd5"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="809e-c586-3e9c-33de"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink import="true" name="Augury scanner" hidden="false" id="a706-9f88-a48e-c0a7" type="selectionEntry" targetId="fede-99f5-4c76-4659">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="28ee-f717-a7f0-611d"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="68c8-3724-946c-5097"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="The Unfavoured" hidden="true" id="ab3a-c6ca-9981-2b89">
+          <comment>Iron Warriors</comment>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="21c0-18db-03dd-ae07" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="594d-fa82-13cb-a345" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5cdb-5355-3a57-79c6"/>
+          </constraints>
+          <infoLinks>
+            <infoLink name="Expendable (X)" id="3a9d-195e-031e-fe40" hidden="false" type="rule" targetId="c4d4-e053-9564-540b">
+              <modifiers>
+                <modifier type="set" value="Expendable (1)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Martial Supremecy" hidden="true" id="2d54-e82c-85eb-0f9e">
+          <comment>Sons of Horus</comment>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fb33-8b56-0d22-a6c0"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="ac06-fcec-b634-5bd9" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="5d5e-958f-e388-50b5" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Martial Supremacy" id="4335-fd54-4bc4-f802" hidden="false">
+              <description>One Model in the Unit selected to ill a Prime Force Organization Slot with this Prime Advantage gains the Champion Sub-type and the Duellist&apos;s Edge (1) special rule.</description>
+            </rule>
+          </rules>
+          <infoLinks>
+            <infoLink name="Duellist&apos;s Edge (X)" id="f822-c356-2fac-e7b5" hidden="false" type="rule" targetId="94bc-c69f-99b6-8ba0">
+              <modifiers>
+                <modifier type="set" value="Duellist&apos;s Edge (1)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Zealous Assault" hidden="true" id="089d-9641-6aea-483b">
+          <comment>Word Bearers</comment>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="4935-1832-63f7-91aa" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="88e6-d373-4152-0dd8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8a85-51a9-79ff-b54c"/>
+          </constraints>
+          <infoLinks>
+            <infoLink name="Impact (X)" id="da1f-8f6a-ccea-f213" hidden="false" type="rule" targetId="6ead-c31c-ab09-2f8c">
+              <modifiers>
+                <modifier type="set" value="Impact (S)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Phoenix Warden" hidden="true" id="eb48-9812-af4c-6912">
+          <comment>Emperor&apos;s Children</comment>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6508-e806-4be5-6e92"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="9a22-d01f-ab5c-ec07" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="5dd5-d00c-b150-34b9" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: Tartaros only. Replace combi-bolter and power weapon with Phoenix power spear. Gains Skill unmatched rule." hidden="false" id="feec-6740-2800-2eb0">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eb02-cea7-9dc0-84ec"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cbf9-1bea-e156-8a1f"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Unnatural Resilience" hidden="true" id="73c6-526b-63cf-a6a9">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="73af-0018-bcc6-47e6"/>
+            <constraint type="max" value="1" field="selections" scope="force" shared="true" id="9ed1-df93-1c0f-ceaf" includeChildSelections="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="be98-aa9d-64ef-f62c" shared="true" includeChildSelections="true"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f613-76c6-e58e-f286" shared="true" includeChildSelections="false"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="5dd5-d00c-b150-34b9" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <infoLinks>
+            <infoLink name="Eternal Warrior (X)" id="9a31-c95b-5d72-0f49" hidden="false" type="rule" targetId="15b4-9e4a-f361-c5a3">
+              <modifiers>
+                <modifier type="set" value="Eternal Warrior (2)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Not Yet Implemented: +1 Wound" hidden="false" id="c7e8-81b9-93c0-8d35">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8563-7c46-255f-2669"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="23a4-782c-47fb-f04d"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <comment>Death Guard</comment>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Telekine Shift" hidden="true" id="3176-6983-2172-fc33">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="24a3-8732-84c2-526d"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="2496-21e2-1870-e9b8" shared="true" includeChildSelections="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="88e6-d373-4152-0dd8" shared="true" includeChildSelections="false"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Telekine Shift" id="3aa8-e3ad-265b-03c7" hidden="false">
+              <description>When the Controlling Player chooses to make a Rush Move with a Unit made of Models with this Special Rule, they may also choose to make a Willpower Check for that Unit. If the Willpower Check is successful, the Unit gains the Antigrav Sub-Type and the Move Through Cover Special Rule until the end of the current Movement Phase. If the Willpower Check is failed, the selected Unit may not Move during the current Movement Phase. </description>
+            </rule>
+          </rules>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
@@ -15680,6 +15941,9 @@ May have it&apos;s power sword exchanged with one frost sword or frost axe for F
               </conditionGroups>
             </modifier>
           </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ed5b-611f-b5c0-b3dd"/>
+          </constraints>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>


### PR DESCRIPTION
I have added the Legion Prime benefits for all Legions. These ones are complete.
Raven Guard
Alpha Legion
White Scars
Thousand Sons
Salamanders
Night Lords
World Eaters
Blood Angels
Iron Warriors
Word Bearers

These ones will still need work as they have features that add to profiles, add units or have gear restrictions.
Dark Angels
Iron Hands
Space Wolves
Imperial Fists
Sons of Horus
Emperor's Children
Death Guard