### PR TITLE
Fix Issue with Prosperine Arcana not shown

### DIFF
--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="21" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="22" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>
@@ -228,6 +228,7 @@
             <entryLink import="true" name="Prime Benefits" hidden="false" id="7e80-d3f0-4b3f-a177" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="a63f-fc3f-b619-049a" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="951e-35bd-6e6e-e22a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -453,6 +454,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="6a6f-8404-6809-deac" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="1919-f38a-998a-e7b4" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Centurion" hidden="false" id="3392-e93d-79bc-d648" sortIndex="4">
@@ -851,6 +853,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="29c3-ea55-74fc-588d" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="0b5d-d2e7-1d99-e361" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -950,6 +953,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
               </costs>
             </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="3308-e7c7-cc0d-3125" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
           </entryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="Melee Weapons:" id="3204-79db-bbc4-2000" hidden="false">
@@ -1434,6 +1438,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3ff0-ab05-85ee-4953" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="f65d-665e-8e67-224c" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="81bb-3774-5033-549a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -1503,6 +1508,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="93cb-7eb1-8a98-b346" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="8d73-0084-f7e4-97d7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Sergeant" hidden="false" id="5809-c342-b9e6-740a" defaultAmount="1" sortIndex="1">
@@ -1905,6 +1911,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="8cd2-bd3a-4ad0-84c8" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="670f-745d-764c-abe5" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="b664-2c88-4125-eee5" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -2458,6 +2465,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="5792-ae2b-89ca-c8e9" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="6bb8-fd9b-2f17-5485" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex=""/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="50"/>
@@ -3052,6 +3060,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="c863-f544-ed5d-c5dc" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7329-57ce-10c2-4c0b" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="25"/>
@@ -3296,6 +3305,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="92fd-983b-5f52-f0cd" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="63ca-dc78-45c8-9071" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="32"/>
@@ -3559,6 +3569,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="a98f-89df-6c9f-1f17" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="36cd-be62-0f8c-19c7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="Line (X)" id="e24e-5c1c-81dd-fdee" hidden="false" type="rule" targetId="1b5d-ceec-802a-c611">
@@ -3641,6 +3652,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="f3a1-79b7-e0f8-bc05" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="155b-0047-db69-53d5" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="May exchange anvilus autocannon battery" id="c6c1-d3eb-7bdf-0e58" hidden="false" defaultSelectionEntryId="5f77-6850-58d7-65c2" sortIndex="2">
@@ -3734,6 +3746,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <modifier type="set" value="20" field="9893-c379-920b-8982"/>
           </modifiers>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="9e7d-2345-2160-3bc8" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="8f8b-544e-d186-b4cf" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -4062,6 +4075,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="5c2c-c897-4f46-b9eb" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="f053-b27d-7e15-547c" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Options" id="d3ff-0c94-ec92-9fd3" hidden="false" sortIndex="4">
@@ -4590,6 +4604,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="9064-ad16-4ca4-aa5b" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="791b-d7c4-9648-fd36" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Optae" hidden="false" id="1653-8dfd-2881-8cec" sortIndex="6">
@@ -4640,6 +4655,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="81b5-3dc6-16f2-e9c7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="3a39-a492-a76c-eca3" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -5160,6 +5176,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="cb99-b830-14db-19d7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Damocles Command Rhino" hidden="false" id="f214-aeb9-0dd6-9071" sortIndex="7">
@@ -5324,6 +5341,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="b8fb-4169-abc0-98cb" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Librarian" hidden="false" id="c0e4-eabd-4f0a-23ca">
@@ -5485,6 +5503,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="cbe3-a214-4061-41d6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="6a0a-f0fe-c889-8a8a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -5635,6 +5654,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="1b1e-7972-ff19-adad" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Esoterist" hidden="false" id="868f-f32d-d5ef-8021" sortIndex="11">
@@ -5725,6 +5745,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="ef9a-f961-2201-eaee" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <categoryLinks>
         <categoryLink targetId="9871-cb62-5283-2216" id="7092-2474-59a0-6090" primary="false" name="Command Model Sub-type"/>
@@ -5776,6 +5797,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="baa6-1d64-d49f-dea0" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Master of Signals" hidden="false" id="f985-ac79-b28b-f341">
@@ -5919,6 +5941,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="580e-3c54-3aac-7c85" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="f17a-8cab-ca53-bba3" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6025,6 +6048,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="2253-d0fc-f7a5-415d" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="85df-8c40-d821-1b11" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="b01e-114a-47d0-e7e0" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6148,6 +6172,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
               </costs>
             </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="ff85-1342-735f-6024" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="9"/>
           </entryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="May exchange bolt pistol for:" id="936d-ae02-5b4c-fb2b" hidden="false" defaultSelectionEntryId="20b3-3f38-2825-efa7" sortIndex="2">
@@ -6320,6 +6345,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="40c1-b87d-22cf-c3d8" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="363d-cd4e-6c14-9ef1" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6419,6 +6445,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="1eff-db01-40d9-add7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Options" id="265f-5c58-0294-dfa9" hidden="false" sortIndex="2">
@@ -6856,6 +6883,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="8c42-ac26-1d89-9950" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="3aee-7cf9-9498-f1fd" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="60"/>
@@ -6878,6 +6906,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="11bd-f489-3aa3-97d7" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7138-7174-e84a-ffd4" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Veteran Champion" hidden="false" id="3dc3-9ea3-a9de-6f25" sortIndex="1">
@@ -7327,6 +7356,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="4a49-fe89-b315-2872" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7c9c-5c2f-a7d5-5565" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Tartaros Chosen" hidden="false" id="a224-6817-4f91-8ecb" sortIndex="2">
@@ -7586,6 +7616,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="1b48-0181-d640-09a1" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="444e-7ecd-d81b-1705" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Cataphractii Terminator" hidden="false" id="f106-8e40-a38f-427c" sortIndex="2">
@@ -7882,6 +7913,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="083c-fd40-e0b2-9c2a" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="9397-a285-59a4-54b6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Seeker" hidden="false" id="f9c6-e107-4e90-5504" sortIndex="2">
@@ -8166,6 +8198,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="6f8d-69ad-9541-64b4" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="82f8-86b9-b0c6-1fbb" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Tartaros Terminator" hidden="false" id="66c8-c209-2f95-c4e8" sortIndex="2">
@@ -8695,6 +8728,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="2b49-57e4-2175-f6f5" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="5318-9db0-630a-9353" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <categoryLinks>
         <categoryLink targetId="594d-fa82-13cb-a345" id="3792-fb77-5653-bc28" primary="false" name="Infantry Model Type"/>
@@ -8733,6 +8767,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="baee-914d-bd20-168b" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="6f10-268e-a29d-3d35" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Legionary" hidden="false" id="9de3-15fa-986b-500a" sortIndex="2">
@@ -9187,6 +9222,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6135-5a9b-f71a-368f" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="c405-8326-3187-4028" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="9eea-baa3-681d-b174" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -9417,6 +9453,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="29f2-c5cd-8c46-974e" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="1269-9bdd-92ac-93fc" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Legion Heavy Weapons List" id="f3e8-47d6-ac92-2b66" hidden="false" collapsible="true" flatten="false" defaultSelectionEntryId="cf76-c4c7-8a9a-0beb" sortIndex="4">
@@ -9572,6 +9609,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="dc2c-561f-ec97-50df" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="b5aa-c79b-d747-f443" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Legiones Astartes]" id="9b70-4c5c-0bb2-aa66" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
@@ -9734,6 +9772,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="0ccc-b717-eb01-806f" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="5700-d124-40aa-c610" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -9859,6 +9898,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <modifier type="set" value="5" field="9893-c379-920b-8982"/>
           </modifiers>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="ef1a-edcb-8e80-ffbb" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="97d8-faab-3b68-5553" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -10595,6 +10635,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="7015-c30f-f062-353e" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="63dc-8c1b-468d-2569" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="77b0-8e50-7e5b-bf4a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -10819,6 +10860,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d21c-df9a-10a8-d07d" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="d00b-181e-0c96-d727" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="130c-24bd-a055-4001" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -11198,6 +11240,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="54b0-06e2-843a-75e5" includeChildSelections="false"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="38f7-9218-224b-9d6a" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Scimitar Sergeant" hidden="false" id="9011-92da-37e3-f605" sortIndex="1">
@@ -11726,6 +11769,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="e21f-a453-b4f4-77a7" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="61b4-4f2d-cc27-d029" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Predator" hidden="false" id="b0ba-83cb-f3bf-bf2e" sortIndex="64">
@@ -11886,6 +11930,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="6dbc-04d5-b089-4b90" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="e821-f090-5e6d-2496" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Land Speeder" hidden="false" id="1f3c-e351-b888-61ef" sortIndex="1">
@@ -13489,6 +13534,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="df8c-86e2-91c4-c049" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="e4cd-e660-606b-9c70" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -13635,6 +13681,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="dfd8-6a36-69f9-17af" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Options" id="02af-aba0-5bd7-6bd2" hidden="false" sortIndex="3">
@@ -14362,7 +14409,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
           </costs>
         </entryLink>
-        <entryLink import="true" name="Graviton Pistol" hidden="true" id="c14d-e2d8-accd-d52b" type="selectionEntry" targetId="320a-5112-0e89-aad4" sortIndex="5">
+        <entryLink import="true" name="Graviton pistol" hidden="true" id="c14d-e2d8-accd-d52b" type="selectionEntry" targetId="320a-5112-0e89-aad4" sortIndex="5">
           <modifiers>
             <modifier type="set" value="false" field="hidden">
               <conditionGroups>
@@ -15654,6 +15701,244 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a343-787f-a2c7-66cd" includeChildSelections="false"/>
         <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2666-2315-4da3-8043" includeChildSelections="false"/>
       </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Prosperine Arcana" id="eafe-beb3-8d27-ec50" hidden="true" collapsible="true" sortIndex="7">
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Athanaean" hidden="false" id="fc42-7d7b-e1ba-8946">
+          <costs>
+            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+            <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+            <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+            <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
+            <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
+          </costs>
+          <profiles>
+            <profile name="Clarity" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="7e8a-247e-9bc2-7bd0" publicationId="e54c-7040-0f35-d85d">
+              <characteristics>
+                <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Psychic Power allows the Controlling Player to remove a Tactical Status from the Unit.</characteristic>
+                <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Clarity Psychic Power in the Effects Sub-Phase of the Start Phase.</characteristic>
+                <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Athanaean Trait and under the Active Player&apos;s control.</characteristic>
+                <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be a Unit under the Active Player&apos;s control, must have at least one Model within 18&quot;and with Line of Sight to the Focus, and must only include models with the Thousand Sons Trait.</characteristic>
+                <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Power are resolved immediately.</characteristic>
+                <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
+2. lf the Manifestation Check is successful, the Controlling Player may select a single Tactical Status any Model in the Target Unit has. This Tactical Status is immediately removed from every Model in the Target Unit.
+3. f the Manifestation Check fails then there is no further effect.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Emanation of Dread" typeId="7d31-7144-3b28-c850" typeName="Psychic Ranged Weapon" hidden="false" id="c129-33fb-09a4-158e" publicationId="e54c-7040-0f35-d85d">
+              <characteristics>
+                <characteristic name="R" typeId="6d86-f7c6-c184-8bf4">24</characteristic>
+                <characteristic name="FP" typeId="99a5-a4b9-8862-5092">3</characteristic>
+                <characteristic name="RS" typeId="ff4a-ab25-1be8-4545">4</characteristic>
+                <characteristic name="AP" typeId="c8d6-d2ec-1344-07e3">-</characteristic>
+                <characteristic name="D" typeId="e840-f63c-5bc4-27b3">1</characteristic>
+                <characteristic name="Special Rules" typeId="e87b-e7a3-5562-a456">Panic (1)</characteristic>
+                <characteristic name="Traits" typeId="a229-21ce-4177-c4b1">Psychic</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Panic (X)" id="41cb-2f68-868c-bc1c" hidden="false" type="rule" targetId="82a7-f471-3fda-6ca1">
+              <modifiers>
+                <modifier type="set" value="Panic (1)" field="name"/>
+              </modifiers>
+              <comment>1</comment>
+            </infoLink>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Corvidae" hidden="false" id="cff7-56bc-7e47-1c7d">
+          <costs>
+            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+            <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+            <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+            <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
+            <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
+          </costs>
+          <profiles>
+            <profile name="Paths of Consequence" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="05e6-9cfb-4643-aef4">
+              <characteristics>
+                <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Power is used in the Start Phase and reduces the target&apos;s Movement as well as causing it to suffer Dangerous Terrain Tests.</characteristic>
+                <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Paths of Consequence Psychic Power in the Effects Sub Phase of the Start Phase.</characteristic>
+                <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Corvidae Trait and must be controlled by the Active Player.</characteristic>
+                <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be a Unit under the control of the Reactive Player with at least one Model within 18 of the Focus and with Line of Sight to the Focus.</characteristic>
+                <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Curse last until the start of the Active Player&apos;s next Turn.</characteristic>
+                <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
+2. If the Manifestation Check is successful, then all Models in the Target Unit suffer a penalty of -2 to their Movement Characteristic, to a minimum of 0. Furthermore, the first time a Model in the Target Unit Moves in a given Phase, it must take a Dangerous Terrain Test.
+3. If the Manifestation Check fails then there is no further effect.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Fated Shots" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="4bcd-8d44-c215-dcae">
+              <characteristics>
+                <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Psychic Power improves the effectiveness of Ranged Attacks made by the Unit.</characteristic>
+                <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Fated Shots Psychic Power in the Shooting Phase, at the start of Step 4 of any Shooting Attack made by a Unit that includes at least one Model with the Corvidae Trait controlled by the Active Player.</characteristic>
+                <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Corvidae Trait that is part of the Unit making the Shooting Attack.</characteristic>
+                <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be the Unit that the Focus is part of, and must only include models with the Thousand Sons Trait.</characteristic>
+                <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Power last until the end of the Shooting Attack being resolved.</characteristic>
+                <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
+2. If the Manifestation Check is successful, then all ranged Weapons Models in the Target Unit have (excluding Weapons with the Blast (X) Special Rule) gain the Rending (5+) Special Rule.
+3. If the Manifestation Check fails then there is no further effect.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Pavoni" hidden="false" id="ef46-38e5-0b94-41c1">
+          <costs>
+            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+            <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+            <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+            <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
+            <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
+          </costs>
+          <profiles>
+            <profile name="Stoneform" typeId="d59e-df4b-630f-f185" typeName="Psychic Reaction" hidden="false" id="0e87-fe08-ef7c-fa67">
+              <characteristics>
+                <characteristic name="Summary" typeId="c8a8-29f2-605b-5969">This Psychic Reaction boosts the Toughness Characteristic of the Reacting Unit.</characteristic>
+                <characteristic name="Trigger" typeId="4e6b-ebca-53df-fcf7">The Reactive Player may choose to declare a Stoneform Psychic Reaction at the start of Step 3 of a Shooting Attack made by the Active Player that targets a Unitwith at least one Model with the Pavoni Trait.</characteristic>
+                <characteristic name="Cost" typeId="f25a-9ced-eb9b-4587">The Reactive Player must spend 1 point of their Reaction Allotment to declare a Stoneform Psychic Reaction.This cost is paid if the Willpower Check is successful. If the Willpower Check fails, the cost is not paid.</characteristic>
+                <characteristic name="Focus" typeId="0b45-591a-ee11-488e">The Focus of this Psychic Reaction must be a Model with the Pavoni Trait under the Reactive Player&apos;s control, and must be a part of the Unit targeted by the Shooting Attack that triggered this Psychic Reaction.</characteristic>
+                <characteristic name="Target" typeId="cf1d-e201-caac-3d45">The Target Unit must be the Unit that the Focus is part of, and must only include models with the Thousand Sons Trait.</characteristic>
+                <characteristic name="Duration" typeId="daae-40ac-68e2-fa78">If successfully Manifested, the effects of this Pychic Reaction last until the end of the Sub-Phase in which it was declared.</characteristic>
+                <characteristic name="Process" typeId="8d43-934e-e511-0cfd">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
+2. If the Manifestation Check is successful, then all Models in the Unit that is the target of the Blessing gain a bonus of +2 to their Toughness Characterisic.
+3. If the Manifestation Check fails then there is no further effect</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Bloodboil" typeId="7d31-7144-3b28-c850" typeName="Psychic Ranged Weapon" hidden="false" id="19a5-f8c9-01a8-0815">
+              <characteristics>
+                <characteristic name="R" typeId="6d86-f7c6-c184-8bf4">12</characteristic>
+                <characteristic name="FP" typeId="99a5-a4b9-8862-5092">1</characteristic>
+                <characteristic name="RS" typeId="ff4a-ab25-1be8-4545">4</characteristic>
+                <characteristic name="AP" typeId="c8d6-d2ec-1344-07e3">2</characteristic>
+                <characteristic name="D" typeId="e840-f63c-5bc4-27b3">2</characteristic>
+                <characteristic name="Special Rules" typeId="e87b-e7a3-5562-a456">Poisoned (2+)</characteristic>
+                <characteristic name="Traits" typeId="a229-21ce-4177-c4b1">Psychic</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Poisoned (X)" id="fc8e-fa0a-0e27-740f" hidden="false" type="rule" targetId="076f-2c91-c58b-71b3">
+              <modifiers>
+                <modifier type="set" value="Poisoned (2+)" field="name"/>
+              </modifiers>
+              <comment>2+</comment>
+            </infoLink>
+          </infoLinks>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Pyrae" hidden="false" id="6c08-592d-ebee-6003">
+          <costs>
+            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+            <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+            <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+            <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
+            <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
+          </costs>
+          <profiles>
+            <profile name="Inferno Shield" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="2d94-c111-3b1e-3939">
+              <characteristics>
+                <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Psychic Power allows a Unit to inflict automatic hits onto a Unit that makes Melee Attacks against them.</characteristic>
+                <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Inferno Shield Psychic Power at the end of the Declare Weapons and Set Initiative Steps Step of a Combat.</characteristic>
+                <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Pyrae Trait and under the Active Player&apos;s control, and must be part of a Unit in that Combat.</characteristic>
+                <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be the Unit that the Focus is part of, and must only include models with the Thousand Sons Trait.</characteristic>
+                <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Power last until the Combat is resolved.</characteristic>
+                <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Controlling the Focus and Target Unit have been decided, Player of the Focus must make a Manifestation Check.
+2. If this Psychic Power is successfully Manifested, then all Models in the Target Unit gain the Inferno Shield Special Rule.
+3. If the Manifestation Check fails then there is no further effect.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Burning Grasp" typeId="f553-2eab-e909-ee56" typeName="Psychic Melee Weapon" hidden="false" id="edb9-a11c-a6f4-a6c6">
+              <characteristics>
+                <characteristic name="IM" typeId="079b-2c1c-979b-1fe0">I</characteristic>
+                <characteristic name="AM" typeId="c6d4-d31f-a563-78f8">1</characteristic>
+                <characteristic name="SM" typeId="562d-ec0b-83ee-541c">8</characteristic>
+                <characteristic name="AP" typeId="46ac-d3d4-36f0-6a1e">3</characteristic>
+                <characteristic name="D" typeId="cca6-168c-5576-e0ee">2</characteristic>
+                <characteristic name="Special Rules" typeId="0da4-845e-b008-2d17">Critical Hit (6+), Breaching (5+), Armourbane</characteristic>
+                <characteristic name="Traits" typeId="dbf5-ab06-5eb4-7d00">Psychic</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink name="Critical Hit (X)" id="5e2b-1d84-6940-26ba" hidden="false" type="rule" targetId="fe5a-a52a-468f-3f88">
+              <modifiers>
+                <modifier type="set" value="Critical Hit (6+)" field="name"/>
+              </modifiers>
+              <comment>6+</comment>
+            </infoLink>
+            <infoLink name="Armourbane" id="9887-507f-0f48-9bf8" hidden="false" type="rule" targetId="36ee-4c54-bced-a696"/>
+            <infoLink name="Breaching (X)" id="b490-ff2b-c47a-d5c9" hidden="false" type="rule" targetId="b094-0b64-eb57-aed6">
+              <modifiers>
+                <modifier type="set" value="Breaching (5+)" field="name"/>
+              </modifiers>
+              <comment>5+</comment>
+            </infoLink>
+          </infoLinks>
+          <rules>
+            <rule name="Inferno Shield" id="f48e-1cf8-7995-ec35" hidden="false">
+              <description>At the end of each Initiative Step, each Unit that scored any Hits against a Unit that contains any Models with this Special Rule suffers D6 Hits with a Strength of 4, an AP of &apos;-&apos; and a Damage of 1, allocated by that Unit&apos;s Controlling Player.</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Raptora" hidden="false" id="ba0e-77b7-36be-8a4e">
+          <costs>
+            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+            <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+            <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+            <cost name="Auxilary Detachment(s)" typeId="3e8e-05ee-be52-12d6" value="0"/>
+            <cost name="Apex Detachment(s)" typeId="159d-855c-533d-f592" value="0"/>
+          </costs>
+          <infoLinks>
+            <infoLink name="Armourbane" id="9af6-4f57-b54b-53f3" hidden="false" type="rule" targetId="36ee-4c54-bced-a696"/>
+            <infoLink name="Shrouded (X)" id="9dc2-ca19-8045-f911" hidden="false" type="rule" targetId="c7e7-3bad-3de0-d6cc">
+              <modifiers>
+                <modifier type="set" value="Shrouded (4+)" field="name"/>
+              </modifiers>
+              <comment>4+</comment>
+            </infoLink>
+            <infoLink name="Force (X)" id="6d0f-3f07-c6f9-a62d" hidden="false" type="rule" targetId="25cd-60d0-a0a4-6b18">
+              <modifiers>
+                <modifier type="set" value="Force (D)" field="name"/>
+              </modifiers>
+              <comment>D</comment>
+            </infoLink>
+          </infoLinks>
+          <profiles>
+            <profile name="Kine Shield" typeId="d59e-df4b-630f-f185" typeName="Psychic Reaction" hidden="false" id="b999-2724-8a1e-421a">
+              <characteristics>
+                <characteristic name="Summary" typeId="c8a8-29f2-605b-5969">This Psychic Reaction allows a Unit to gain a Shrouded Damage Mitigation Roll.</characteristic>
+                <characteristic name="Trigger" typeId="4e6b-ebca-53df-fcf7">The Reactive Player may choose to declare a Kine Shield Psychic Reaction at the start of Step 3 of a Shooting Attack made by the Active Player that targets a Unit that includes at least one Model with the Raptora Trait.</characteristic>
+                <characteristic name="Cost" typeId="f25a-9ced-eb9b-4587">The Reactive Player must spend 1 point of their Reaction Allotment to declare a Kine Shield Psychic Reaction. This cost is paid if the Willpower Check is successful. If the Willpower Check fails, the cost is not paid.</characteristic>
+                <characteristic name="Focus" typeId="0b45-591a-ee11-488e">The Focus of this Psychic Reaction must be a Model with the Raptora Trait under the Reactive Player&apos;s control, and must be a part of the Unit targeted by the Shooting Attack that triggered this Psychic Reaction.</characteristic>
+                <characteristic name="Target" typeId="cf1d-e201-caac-3d45">The Target Unit must be the Unit that the Focus is part of, that is the target of the Shooting Attack that triggered the Reaction and must include only Models with the Thousand Sons Trait.</characteristic>
+                <characteristic name="Duration" typeId="daae-40ac-68e2-fa78">lf successfully Manifested the effects of this Psychic Reaction last until the end of the Sub-Phase in which it was declared.</characteristic>
+                <characteristic name="Process" typeId="8d43-934e-e511-0cfd">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
+2. If the Manifestation Check is successful, then all Models in the Target Unit gain a 4+ Shrouded Damage Mitigation Roll against any wounds inflicted.
+3. If the Manifestation Check fails then there is no further effect.</characteristic>
+              </characteristics>
+            </profile>
+            <profile name="Crushing Force" typeId="7d31-7144-3b28-c850" typeName="Psychic Ranged Weapon" hidden="false" id="6839-ed41-6a24-3f0d">
+              <characteristics>
+                <characteristic name="R" typeId="6d86-f7c6-c184-8bf4">24</characteristic>
+                <characteristic name="FP" typeId="99a5-a4b9-8862-5092">3</characteristic>
+                <characteristic name="RS" typeId="ff4a-ab25-1be8-4545">4</characteristic>
+                <characteristic name="AP" typeId="c8d6-d2ec-1344-07e3">-</characteristic>
+                <characteristic name="D" typeId="e840-f63c-5bc4-27b3">1</characteristic>
+                <characteristic name="Special Rules" typeId="e87b-e7a3-5562-a456">Armourbane, Force (D)</characteristic>
+                <characteristic name="Traits" typeId="a229-21ce-4177-c4b1">Psychic</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6aa3-a02d-239a-3975"/>
+      </constraints>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <infoLinks>

--- a/Thousand Sons.cat
+++ b/Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="6" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="7" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Magnus the Red" hidden="false" id="cf2e-fa27-23ce-7502">
       <selectionEntries>
@@ -60,61 +60,52 @@
               </modifiers>
               <comment>6+</comment>
             </infoLink>
-            <infoLink name="Prosperine Arcana" id="378b-5ba6-bac0-897a" hidden="false" type="rule" targetId="4af2-be40-b027-468a"/>
             <infoLink name="Cult Arcana" id="1b94-69e3-209c-882a" hidden="false" type="rule" targetId="f622-94c0-3997-9ee5"/>
           </infoLinks>
           <entryLinks>
-            <entryLink import="true" name="Athanaean" hidden="false" id="faf2-fbab-e1ca-0b25" type="selectionEntry" targetId="b82f-e92e-222b-37e0" sortIndex="3">
+            <entryLink import="true" name="Athanaean" hidden="false" id="e354-0333-bece-8322" type="selectionEntry" targetId="fc42-7d7b-e1ba-8946" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+              </costs>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e0e6-857f-7b99-12a5" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5423-333e-cdeb-4f19" includeChildSelections="false"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink name="Athanaen" hidden="false" id="bfc4-9585-76fe-f2d1" targetId="b582-64ed-5b52-23cb" primary="false"/>
-              </categoryLinks>
-              <infoLinks>
-                <infoLink name="Panic (X)" id="2d9a-b349-66ee-d34c" hidden="false" type="rule" targetId="82a7-f471-3fda-6ca1">
-                  <modifiers>
-                    <modifier type="set" value="Panic (1)" field="name"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-            </entryLink>
-            <entryLink import="true" name="Corvidae" hidden="false" id="16a7-989e-9af2-3e43" type="selectionEntry" targetId="4c49-dc8e-fba8-15cc" sortIndex="4">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e257-0c7f-c52e-934a-min" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e257-0c7f-c52e-934a-max" includeChildSelections="false"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink name="Corvidae" hidden="false" id="badc-d6ed-5161-45e2" targetId="195c-d66b-8b86-c5ad" primary="false"/>
-              </categoryLinks>
-            </entryLink>
-            <entryLink import="true" name="Pavoni" hidden="false" id="c859-19ea-795f-cfec" type="selectionEntry" targetId="d974-a32c-8a71-ecf3" sortIndex="5">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9a2e-ba8a-c616-905c-min" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9a2e-ba8a-c616-905c-max" includeChildSelections="false"/>
-              </constraints>
-              <categoryLinks>
-                <categoryLink name="Pavoni" hidden="false" id="9f94-a957-a6a4-5f56" targetId="1ffd-75cd-4550-fe8f" primary="false"/>
-              </categoryLinks>
-              <infoLinks>
-                <infoLink name="Poisoned (X)" id="8020-afab-f4b6-5546" hidden="false" type="rule" targetId="076f-2c91-c58b-71b3">
-                  <modifiers>
-                    <modifier type="set" value="Poisoned (2+)" field="name"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
-            </entryLink>
-            <entryLink import="true" name="Pyrae" hidden="false" id="f873-7cc9-d766-f354" type="selectionEntry" targetId="2063-723f-a56a-a848" sortIndex="6">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4200-8722-cdd5-2b90-min" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4200-8722-cdd5-2b90-max" includeChildSelections="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4dac-a8b8-bd14-7f50" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f349-0816-3075-a914" includeChildSelections="false"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Raptora" hidden="false" id="c692-088a-f175-c4dc" type="selectionEntry" targetId="7b1f-851d-700e-46d8" sortIndex="7">
+            <entryLink import="true" name="Corvidae" hidden="false" id="7e59-6ca4-3aa7-02cc" type="selectionEntry" targetId="cff7-56bc-7e47-1c7d" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+              </costs>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7e6d-71e8-8e51-220d-min" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7e6d-71e8-8e51-220d-max" includeChildSelections="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8e83-c61b-5185-6348" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b25e-081a-6d75-3103" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Pavoni" hidden="false" id="b75c-c354-8ed4-729d" type="selectionEntry" targetId="ef46-38e5-0b94-41c1" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+              </costs>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a2fb-4c65-9f59-ca25" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3953-973d-8851-cd5b" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Pyrae" hidden="false" id="effe-06e8-f496-77b7" type="selectionEntry" targetId="6c08-592d-ebee-6003" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+              </costs>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="77a4-8f41-310c-4f01" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a25b-e713-1d13-cbf9" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Raptora" hidden="false" id="0a6b-bc63-0415-262c" type="selectionEntry" targetId="ba0e-77b7-36be-8a4e" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+              </costs>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cfc7-726f-b832-9b79" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9316-e3bb-6fe1-b5ea" includeChildSelections="false"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -296,7 +287,6 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
           </costs>
           <infoLinks>
-            <infoLink name="Prosperine Arcana" id="c04b-0426-c88e-25ed" hidden="false" type="rule" targetId="4af2-be40-b027-468a"/>
             <infoLink name="Cult Arcana" id="1227-ad6c-ee0d-cac7" hidden="false" type="rule" targetId="f622-94c0-3997-9ee5"/>
           </infoLinks>
           <entryLinks>
@@ -324,16 +314,19 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="03dd-778e-bca9-4fb0-max" includeChildSelections="false"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Corvidae" hidden="false" id="c793-dd3e-4d6d-a5be" type="selectionEntry" targetId="4c49-dc8e-fba8-15cc" sortIndex="5">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="320d-e87d-484f-c5c8-min" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="320d-e87d-484f-c5c8-max" includeChildSelections="false"/>
-              </constraints>
-            </entryLink>
             <entryLink import="true" name="Thaumaturgy" hidden="false" id="1288-a605-46ca-2fcc" type="selectionEntry" targetId="15a9-e44f-2393-0d6a" sortIndex="7">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="05b0-4fa7-1b73-32c3-min" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="05b0-4fa7-1b73-32c3-max" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Corvidae" hidden="false" id="d44d-d15c-337a-2f64" type="selectionEntry" targetId="cff7-56bc-7e47-1c7d">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+              </costs>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e8a3-7ff7-22c9-3f43" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9b8a-0a86-c8b1-e18d" includeChildSelections="false"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -410,230 +403,6 @@ Until the end of the first Battle Turn of the Battle, whenever the Controlling P
           </entryLinks>
         </entryLink>
       </entryLinks>
-    </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Athanaean" hidden="false" id="b82f-e92e-222b-37e0">
-      <costs>
-        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="b582-64ed-5b52-23cb" id="3c62-4609-7864-6a43" primary="false" name="Athanaen"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Clarity" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="0202-59b1-5aa4-16cb" publicationId="e54c-7040-0f35-d85d">
-          <characteristics>
-            <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Psychic Power allows the Controlling Player to remove a Tactical Status from the Unit.</characteristic>
-            <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Clarity Psychic Power in the Effects Sub-Phase of the Start Phase.</characteristic>
-            <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Athanaean Trait and under the Active Player&apos;s control.</characteristic>
-            <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be a Unit under the Active Player&apos;s control, must have at least one Model within 18&quot;and with Line of Sight to the Focus, and must only include models with the Thousand Sons Trait.</characteristic>
-            <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Power are resolved immediately.</characteristic>
-            <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
-2. lf the Manifestation Check is successful, the Controlling Player may select a single Tactical Status any Model in the Target Unit has. This Tactical Status is immediately removed from every Model in the Target Unit.
-3. f the Manifestation Check fails then there is no further effect.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Emanation of Dread" typeId="7d31-7144-3b28-c850" typeName="Psychic Ranged Weapon" hidden="false" id="599f-e0d7-8f9c-54d7" publicationId="e54c-7040-0f35-d85d">
-          <characteristics>
-            <characteristic name="R" typeId="6d86-f7c6-c184-8bf4">24</characteristic>
-            <characteristic name="FP" typeId="99a5-a4b9-8862-5092">3</characteristic>
-            <characteristic name="RS" typeId="ff4a-ab25-1be8-4545">4</characteristic>
-            <characteristic name="AP" typeId="c8d6-d2ec-1344-07e3">-</characteristic>
-            <characteristic name="D" typeId="e840-f63c-5bc4-27b3">1</characteristic>
-            <characteristic name="Special Rules" typeId="e87b-e7a3-5562-a456">Panic (1)</characteristic>
-            <characteristic name="Traits" typeId="a229-21ce-4177-c4b1">Psychic</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Panic (X)" id="e669-e024-1317-a0f7" hidden="false" type="rule" targetId="82a7-f471-3fda-6ca1">
-          <modifiers>
-            <modifier type="set" value="Panic (1)" field="name"/>
-          </modifiers>
-          <comment>1</comment>
-        </infoLink>
-      </infoLinks>
-    </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Corvidae" hidden="false" id="4c49-dc8e-fba8-15cc">
-      <costs>
-        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="195c-d66b-8b86-c5ad" id="6346-525e-2e2e-36b7" primary="false" name="Corvidae"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Paths of Consequence" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="c40d-0b01-260f-bf14">
-          <characteristics>
-            <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Power is used in the Start Phase and reduces the target&apos;s Movement as well as causing it to suffer Dangerous Terrain Tests.</characteristic>
-            <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Paths of Consequence Psychic Power in the Effects Sub Phase of the Start Phase.</characteristic>
-            <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Corvidae Trait and must be controlled by the Active Player.</characteristic>
-            <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be a Unit under the control of the Reactive Player with at least one Model within 18 of the Focus and with Line of Sight to the Focus.</characteristic>
-            <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Curse last until the start of the Active Player&apos;s next Turn.</characteristic>
-            <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
-2. If the Manifestation Check is successful, then all Models in the Target Unit suffer a penalty of -2 to their Movement Characteristic, to a minimum of 0. Furthermore, the first time a Model in the Target Unit Moves in a given Phase, it must take a Dangerous Terrain Test.
-3. If the Manifestation Check fails then there is no further effect.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Fated Shots" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="f83e-a7ac-9834-5050">
-          <characteristics>
-            <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Psychic Power improves the effectiveness of Ranged Attacks made by the Unit.</characteristic>
-            <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Fated Shots Psychic Power in the Shooting Phase, at the start of Step 4 of any Shooting Attack made by a Unit that includes at least one Model with the Corvidae Trait controlled by the Active Player.</characteristic>
-            <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Corvidae Trait that is part of the Unit making the Shooting Attack.</characteristic>
-            <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be the Unit that the Focus is part of, and must only include models with the Thousand Sons Trait.</characteristic>
-            <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Power last until the end of the Shooting Attack being resolved.</characteristic>
-            <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
-2. If the Manifestation Check is successful, then all ranged Weapons Models in the Target Unit have (excluding Weapons with the Blast (X) Special Rule) gain the Rending (5+) Special Rule.
-3. If the Manifestation Check fails then there is no further effect.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-    </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Pavoni" hidden="false" id="d974-a32c-8a71-ecf3">
-      <costs>
-        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-      </costs>
-      <categoryLinks>
-        <categoryLink targetId="1ffd-75cd-4550-fe8f" id="712d-d7be-f552-4b4f" primary="false" name="Pavoni"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Stoneform" typeId="d59e-df4b-630f-f185" typeName="Psychic Reaction" hidden="false" id="5d1d-7388-264b-cf2e">
-          <characteristics>
-            <characteristic name="Summary" typeId="c8a8-29f2-605b-5969">This Psychic Reaction boosts the Toughness Characteristic of the Reacting Unit.</characteristic>
-            <characteristic name="Trigger" typeId="4e6b-ebca-53df-fcf7">The Reactive Player may choose to declare a Stoneform Psychic Reaction at the start of Step 3 of a Shooting Attack made by the Active Player that targets a Unitwith at least one Model with the Pavoni Trait.</characteristic>
-            <characteristic name="Cost" typeId="f25a-9ced-eb9b-4587">The Reactive Player must spend 1 point of their Reaction Allotment to declare a Stoneform Psychic Reaction.This cost is paid if the Willpower Check is successful. If the Willpower Check fails, the cost is not paid.</characteristic>
-            <characteristic name="Focus" typeId="0b45-591a-ee11-488e">The Focus of this Psychic Reaction must be a Model with the Pavoni Trait under the Reactive Player&apos;s control, and must be a part of the Unit targeted by the Shooting Attack that triggered this Psychic Reaction.</characteristic>
-            <characteristic name="Target" typeId="cf1d-e201-caac-3d45">The Target Unit must be the Unit that the Focus is part of, and must only include models with the Thousand Sons Trait.</characteristic>
-            <characteristic name="Duration" typeId="daae-40ac-68e2-fa78">If successfully Manifested, the effects of this Pychic Reaction last until the end of the Sub-Phase in which it was declared.</characteristic>
-            <characteristic name="Process" typeId="8d43-934e-e511-0cfd">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
-2. If the Manifestation Check is successful, then all Models in the Unit that is the target of the Blessing gain a bonus of +2 to their Toughness Characterisic.
-3. If the Manifestation Check fails then there is no further effect</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Bloodboil" typeId="7d31-7144-3b28-c850" typeName="Psychic Ranged Weapon" hidden="false" id="e0eb-fff3-c9cb-7a51">
-          <characteristics>
-            <characteristic name="R" typeId="6d86-f7c6-c184-8bf4">12</characteristic>
-            <characteristic name="FP" typeId="99a5-a4b9-8862-5092">1</characteristic>
-            <characteristic name="RS" typeId="ff4a-ab25-1be8-4545">4</characteristic>
-            <characteristic name="AP" typeId="c8d6-d2ec-1344-07e3">2</characteristic>
-            <characteristic name="D" typeId="e840-f63c-5bc4-27b3">2</characteristic>
-            <characteristic name="Special Rules" typeId="e87b-e7a3-5562-a456">Poisoned (2+)</characteristic>
-            <characteristic name="Traits" typeId="a229-21ce-4177-c4b1">Psychic</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Poisoned (X)" id="92ca-8fe5-df1b-c8ef" hidden="false" type="rule" targetId="076f-2c91-c58b-71b3">
-          <modifiers>
-            <modifier type="set" value="Poisoned (2+)" field="name"/>
-          </modifiers>
-          <comment>2+</comment>
-        </infoLink>
-      </infoLinks>
-    </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Pyrae" hidden="false" id="2063-723f-a56a-a848">
-      <costs>
-        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-      </costs>
-      <profiles>
-        <profile name="Inferno Shield" typeId="9dfb-2fa3-00e7-8cfd" typeName="Psychic Power" hidden="false" id="1208-d227-ee86-9d36">
-          <characteristics>
-            <characteristic name="Summary" typeId="981f-bb86-6a74-9b20">This Psychic Power allows a Unit to inflict automatic hits onto a Unit that makes Melee Attacks against them.</characteristic>
-            <characteristic name="Trigger" typeId="1be9-f118-1cf3-357e">The Active Player may choose to Manifest the Inferno Shield Psychic Power at the end of the Declare Weapons and Set Initiative Steps Step of a Combat.</characteristic>
-            <characteristic name="Focus" typeId="3f2d-f6e7-e6d3-1f86">The Focus of the Power must be a Model with the Pyrae Trait and under the Active Player&apos;s control, and must be part of a Unit in that Combat.</characteristic>
-            <characteristic name="Target" typeId="2ba0-fbf8-ed6c-3770">The Target Unit must be the Unit that the Focus is part of, and must only include models with the Thousand Sons Trait.</characteristic>
-            <characteristic name="Duration" typeId="d7d5-5b31-5b37-66c4">If successfully Manifested, the effects of this Psychic Power last until the Combat is resolved.</characteristic>
-            <characteristic name="Process" typeId="3804-b2cf-9f1a-4ff0">1. Once the Controlling the Focus and Target Unit have been decided, Player of the Focus must make a Manifestation Check.
-2. If this Psychic Power is successfully Manifested, then all Models in the Target Unit gain the Inferno Shield Special Rule.
-3. If the Manifestation Check fails then there is no further effect.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Burning Grasp" typeId="f553-2eab-e909-ee56" typeName="Psychic Melee Weapon" hidden="false" id="8297-0cc2-6338-1886">
-          <characteristics>
-            <characteristic name="IM" typeId="079b-2c1c-979b-1fe0">I</characteristic>
-            <characteristic name="AM" typeId="c6d4-d31f-a563-78f8">1</characteristic>
-            <characteristic name="SM" typeId="562d-ec0b-83ee-541c">8</characteristic>
-            <characteristic name="AP" typeId="46ac-d3d4-36f0-6a1e">3</characteristic>
-            <characteristic name="D" typeId="cca6-168c-5576-e0ee">2</characteristic>
-            <characteristic name="Special Rules" typeId="0da4-845e-b008-2d17">Critical Hit (6+), Breaching (5+), Armourbane</characteristic>
-            <characteristic name="Traits" typeId="dbf5-ab06-5eb4-7d00">Psychic</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Critical Hit (X)" id="c71c-eeb3-971f-f571" hidden="false" type="rule" targetId="fe5a-a52a-468f-3f88">
-          <modifiers>
-            <modifier type="set" value="Critical Hit (6+)" field="name"/>
-          </modifiers>
-          <comment>6+</comment>
-        </infoLink>
-        <infoLink name="Armourbane" id="7607-482d-dfc3-30ce" hidden="false" type="rule" targetId="36ee-4c54-bced-a696"/>
-        <infoLink name="Breaching (X)" id="39cf-e4fc-ae67-5ff1" hidden="false" type="rule" targetId="b094-0b64-eb57-aed6">
-          <modifiers>
-            <modifier type="set" value="Breaching (5+)" field="name"/>
-          </modifiers>
-          <comment>5+</comment>
-        </infoLink>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink targetId="25e1-2398-085a-1aea" id="8d4c-8c31-7848-7690" primary="false" name="Pyrae"/>
-      </categoryLinks>
-      <rules>
-        <rule name="Inferno Shield" id="d9f8-894d-75c0-6a49" hidden="false">
-          <description>At the end of each Initiative Step, each Unit that scored any Hits against a Unit that contains any Models with this Special Rule suffers D6 Hits with a Strength of 4, an AP of &apos;-&apos; and a Damage of 1, allocated by that Unit&apos;s Controlling Player.</description>
-        </rule>
-      </rules>
-    </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Raptora" hidden="false" id="7b1f-851d-700e-46d8" publicationId="e54c-7040-0f35-d85d">
-      <costs>
-        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-      </costs>
-      <infoLinks>
-        <infoLink name="Armourbane" id="ec8e-a317-c0e3-eaa4" hidden="false" type="rule" targetId="36ee-4c54-bced-a696"/>
-        <infoLink name="Shrouded (X)" id="725f-4aef-4a86-4026" hidden="false" type="rule" targetId="c7e7-3bad-3de0-d6cc">
-          <modifiers>
-            <modifier type="set" value="Shrouded (4+)" field="name"/>
-          </modifiers>
-          <comment>4+</comment>
-        </infoLink>
-        <infoLink name="Force (X)" id="8e60-794f-7de5-e952" hidden="false" type="rule" targetId="25cd-60d0-a0a4-6b18">
-          <modifiers>
-            <modifier type="set" value="Force (D)" field="name"/>
-          </modifiers>
-          <comment>D</comment>
-        </infoLink>
-      </infoLinks>
-      <profiles>
-        <profile name="Kine Shield" typeId="d59e-df4b-630f-f185" typeName="Psychic Reaction" hidden="false" id="1acc-f57c-04af-b54a">
-          <characteristics>
-            <characteristic name="Summary" typeId="c8a8-29f2-605b-5969">This Psychic Reaction allows a Unit to gain a Shrouded Damage Mitigation Roll.</characteristic>
-            <characteristic name="Trigger" typeId="4e6b-ebca-53df-fcf7">The Reactive Player may choose to declare a Kine Shield Psychic Reaction at the start of Step 3 of a Shooting Attack made by the Active Player that targets a Unit that includes at least one Model with the Raptora Trait.</characteristic>
-            <characteristic name="Cost" typeId="f25a-9ced-eb9b-4587">The Reactive Player must spend 1 point of their Reaction Allotment to declare a Kine Shield Psychic Reaction. This cost is paid if the Willpower Check is successful. If the Willpower Check fails, the cost is not paid.</characteristic>
-            <characteristic name="Focus" typeId="0b45-591a-ee11-488e">The Focus of this Psychic Reaction must be a Model with the Raptora Trait under the Reactive Player&apos;s control, and must be a part of the Unit targeted by the Shooting Attack that triggered this Psychic Reaction.</characteristic>
-            <characteristic name="Target" typeId="cf1d-e201-caac-3d45">The Target Unit must be the Unit that the Focus is part of, that is the target of the Shooting Attack that triggered the Reaction and must include only Models with the Thousand Sons Trait.</characteristic>
-            <characteristic name="Duration" typeId="daae-40ac-68e2-fa78">lf successfully Manifested the effects of this Psychic Reaction last until the end of the Sub-Phase in which it was declared.</characteristic>
-            <characteristic name="Process" typeId="8d43-934e-e511-0cfd">1. Once the Focus and Target Unit have been decided, the Controlling Player of the Focus must make a Manifestation Check.
-2. If the Manifestation Check is successful, then all Models in the Target Unit gain a 4+ Shrouded Damage Mitigation Roll against any wounds inflicted.
-3. If the Manifestation Check fails then there is no further effect.</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Crushing Force" typeId="7d31-7144-3b28-c850" typeName="Psychic Ranged Weapon" hidden="false" id="4002-0e9a-b104-4a2f">
-          <characteristics>
-            <characteristic name="R" typeId="6d86-f7c6-c184-8bf4">24</characteristic>
-            <characteristic name="FP" typeId="99a5-a4b9-8862-5092">3</characteristic>
-            <characteristic name="RS" typeId="ff4a-ab25-1be8-4545">4</characteristic>
-            <characteristic name="AP" typeId="c8d6-d2ec-1344-07e3">-</characteristic>
-            <characteristic name="D" typeId="e840-f63c-5bc4-27b3">1</characteristic>
-            <characteristic name="Special Rules" typeId="e87b-e7a3-5562-a456">Armourbane, Force (D)</characteristic>
-            <characteristic name="Traits" typeId="a229-21ce-4177-c4b1">Psychic</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink targetId="b148-3740-2c66-0b53" id="7494-0ac9-68c3-847a" primary="false" name="Raptora"/>
-      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Magistus Amon" hidden="false" id="b0a0-fbcd-0605-47df">
       <selectionEntries>
@@ -1321,7 +1090,6 @@ Immovable Force (Telekinesis Discipline)</description>
           <comment>2</comment>
         </infoLink>
         <infoLink name="Slow and Purposeful" id="5f87-c024-1696-2050" hidden="false" type="rule" targetId="6a8e-e508-abc9-cb3e"/>
-        <infoLink name="Cult Arcana" id="de54-ca29-2ab0-5a99" hidden="false" type="rule" targetId="f622-94c0-3997-9ee5"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink targetId="9254-b1e9-98b2-6101" id="4b93-a0cc-6f5d-a89f" primary="false" name="Psyker"/>
@@ -1334,6 +1102,7 @@ Immovable Force (Telekinesis Discipline)</description>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="7b7d-8fd8-4f7f-ade0" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="d8c7-d798-8107-6546" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Paired Achea pattern force sword" hidden="false" id="3a16-3c8d-bb61-705b">
@@ -1591,7 +1360,6 @@ The &apos;Khenetai&apos; Trait</description>
             </profile>
           </profiles>
           <entryLinks>
-            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="0b7a-75be-7b1b-b353" type="selectionEntryGroup" targetId="9649-e1fd-53ca-9ee9" sortIndex="6"/>
             <entryLink import="true" name="Havoc launcher" hidden="false" id="cbbe-c095-8970-d4d0" type="selectionEntry" targetId="0295-e35d-2ed6-f28a" sortIndex="4">
               <costs>
                 <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
@@ -1609,6 +1377,7 @@ The &apos;Khenetai&apos; Trait</description>
             </entryLink>
             <entryLink import="true" name="Allegiance Traits" hidden="false" id="c7db-6601-badb-a71d" type="selectionEntryGroup" targetId="edd3-9763-97ca-0323"/>
             <entryLink import="true" name="Legiones Astartes Trait" hidden="false" id="a03b-99b3-ee98-750d" type="selectionEntryGroup" targetId="3014-5f25-bc3b-4675"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="54df-974c-b297-0c96" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
           </entryLinks>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Gravis force blade" hidden="false" id="9b5d-00d1-3be9-1580" sortIndex="1">
@@ -1966,58 +1735,6 @@ the Psychic Power was from a Prosperine Arcana to a Model in this Unit instead. 
     <catalogueLink type="catalogue" name="Psychic" id="0c9e-bf57-21df-b03e" targetId="1b2d-2038-39a7-f387" importRootEntries="true"/>
   </catalogueLinks>
   <sharedSelectionEntryGroups>
-    <selectionEntryGroup name="Prosperine Arcana" id="9649-e1fd-53ca-9ee9" hidden="false" publicationId="e54c-7040-0f35-d85d" collapsible="true">
-      <entryLinks>
-        <entryLink import="true" name="Athanaean" hidden="false" id="7f89-b45a-ace2-f598" type="selectionEntry" targetId="b82f-e92e-222b-37e0">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="d2e5-54bb-7350-cdd7" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7e21-650f-856d-693b" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Corvidae" hidden="false" id="a46d-3538-4be3-eca9" type="selectionEntry" targetId="4c49-dc8e-fba8-15cc">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0ee5-e52f-02ec-2e6a" includeChildSelections="false"/>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="52cd-acc5-d792-8ab2" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Pavoni" hidden="false" id="67af-d402-5633-8229" type="selectionEntry" targetId="d974-a32c-8a71-ecf3">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="93c6-bdb5-2646-73a2" includeChildSelections="false"/>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="fb4a-437e-1023-691c" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Pyrae" hidden="false" id="33b5-88e9-04e9-c624" type="selectionEntry" targetId="2063-723f-a56a-a848">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3aff-f58b-f0cf-852f" includeChildSelections="false"/>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="6173-e09f-50dd-6952" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Raptora" hidden="false" id="47bc-3c62-efed-16c5" type="selectionEntry" targetId="7b1f-851d-700e-46d8">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f36d-a48d-539d-0cc6" includeChildSelections="false"/>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="9300-0a69-3512-68eb" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <infoLinks>
-        <infoLink name="Prosperine Arcana" id="d0e9-6d17-a432-1aa2" hidden="false" type="rule" targetId="4af2-be40-b027-468a"/>
-      </infoLinks>
-    </selectionEntryGroup>
     <selectionEntryGroup name="Heavy Weapons" id="a337-e1c1-1db1-ee00" hidden="false" collective="true">
       <constraints>
         <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="7b36-12da-ed73-5556" includeChildSelections="false"/>
@@ -2139,19 +1856,6 @@ the Psychic Power was from a Prosperine Arcana to a Model in this Unit instead. 
     </rule>
     <rule name="Sire of the Thousand Sons" id="eeb4-4067-9bb3-abc2" hidden="false" publicationId="e54c-7040-0f35-d85d">
       <description>Until the end of the first Battle Turn of the Battle, whenever the Controlling Player of a Model with this Special Rule makes a Manifestation Check for a Unit that only includes Models with the Thousand Sons Trait, they may roll three Dice and select any two to determine the result.</description>
-    </rule>
-    <rule name="Prosperine Arcana" id="4af2-be40-b027-468a" hidden="true">
-      <description>If a Model Manifesting a Psychic Power, Psychic Weapon or Psychic Reaction gained from a Prosperine Arcana suffers the effects of Perils of the Warp, do not roll on the Perils of the Warp table. Instead, the Unit suffers D3 wounds, each with an AP of 2 and a Damage of1 which ignore all Cover Saves and Damage Mitigation Rolls.
-Invulnerable Saves may be taken against these wounds as normal and these wounds are allocated as if they were inflicted by a Shooting Attack.
-
-If a Unit that has a Prosperine Arcana is granted a Psychic Weapon, only one Model in that Unit may use that Psychic Weapon each time that Unit is selected to make attacks as part of a Shooting Attack or a Combat.</description>
-      <modifiers>
-        <modifier type="set" value="false" field="hidden">
-          <conditions>
-            <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
-          </conditions>
-        </modifier>
-      </modifiers>
     </rule>
   </sharedRules>
 </catalogue>


### PR DESCRIPTION
- moved Prosperine Arcana definition to LegionAstartes.Cat
- added link to  PA to  all eligable entries
- updated TS specific chars to get correct arcana
- this fixes https://github.com/BSData/horus-heresy-3rd-edition/issues/628
TS Selection:
Magnus 
<img width="1479" height="774" alt="grafik" src="https://github.com/user-attachments/assets/22d9f8db-67cc-424f-8ced-932bf7ebbfe7" />
Generic Legionary:
<img width="1508" height="825" alt="grafik" src="https://github.com/user-attachments/assets/b70c9dec-b4ae-439a-8709-ec0e7f8304a2" />
Centurion:
<img width="1529" height="685" alt="grafik" src="https://github.com/user-attachments/assets/3ae1080d-1f1f-4e8a-b067-337bee705960" />
Vehicle:
<img width="1530" height="619" alt="grafik" src="https://github.com/user-attachments/assets/b8bb40d8-a1ff-4d40-b4b9-c7215d471eed" />
Other Legion
<img width="1527" height="850" alt="grafik" src="https://github.com/user-attachments/assets/e04e87a3-967b-4bb5-a5d5-d2c2f9d50831" />
