### PR TITLE
Fix to Javelin Squadron and Land Speeder Squadron

### DIFF
--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -11833,7 +11833,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Javelin Squadron" hidden="false" id="50f3-fca2-49ab-6de4" sortIndex="62" defaultAmount="1,3">
+    <selectionEntry type="unit" import="true" name="Javelin Speeder Squadron" hidden="false" id="50f3-fca2-49ab-6de4" sortIndex="62" defaultAmount="1,3">
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Javelin Speeder" hidden="false" id="bcab-d669-63bc-66fd" publicationId="b905-0414-1057-bb34" page="101">
           <profiles>
@@ -11872,62 +11872,43 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
           </costs>
           <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange cyclone missile launcher for:" id="0374-2b0c-4218-e502" hidden="false" sortIndex="2">
-              <infoLinks>
-                <infoLink name="Lascannon" id="88be-6763-9a75-487f" hidden="false" type="selectionEntry" targetId="b6d5-4be2-c37e-2197" sortIndex="4">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-                  </costs>
-                  <modifiers>
-                    <modifier type="set" value="Two lascannon" field="name"/>
-                  </modifiers>
-                </infoLink>
-                <infoLink name="Heavy flamer" id="3925-bccb-33e6-7412" hidden="false" type="selectionEntry" targetId="4fa7-ea45-2a89-ad86" sortIndex="2">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
-                  </costs>
+            <selectionEntryGroup name="May exchange cyclone missile launcher for:" id="1870-05ef-278b-a1bb" hidden="false" defaultSelectionEntryId="e703-3d7c-d27c-84be" sortIndex="2">
+              <entryLinks>
+                <entryLink import="true" name="Cyclone missile launcher" hidden="false" id="e703-3d7c-d27c-84be" type="selectionEntry" targetId="b341-159d-9dfb-ff31" sortIndex="1" defaultAmount="1"/>
+                <entryLink import="true" name="Heavy flamer" hidden="false" id="20b1-860c-80eb-05b1" type="selectionEntry" targetId="4fa7-ea45-2a89-ad86" sortIndex="2">
                   <modifiers>
                     <modifier type="set" value="Two heavy flamers" field="name"/>
                   </modifiers>
-                </infoLink>
-                <infoLink name="Heavy bolter" id="98ef-7a9d-a40c-b44b" hidden="false" type="selectionEntry" targetId="bc40-b14a-978e-0232" defaultAmount="2" sortIndex="3">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
-                  </costs>
+                </entryLink>
+                <entryLink import="true" name="Heavy bolter" hidden="false" id="18ad-55fb-5752-e372" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="3">
                   <modifiers>
                     <modifier type="set" value="Two heavy bolters" field="name"/>
                   </modifiers>
-                </infoLink>
-                <infoLink name="Volkite culverin" id="9142-45c5-f92b-83a1" hidden="false" type="selectionEntry" targetId="fcf0-9c1b-d51e-6bc7" sortIndex="5">
+                </entryLink>
+                <entryLink import="true" name="Lascannon" hidden="false" id="525f-10c2-ed00-9df9" type="selectionEntry" targetId="b6d5-4be2-c37e-2197" sortIndex="5">
+                  <modifiers>
+                    <modifier type="set" value="Two lascannon" field="name"/>
+                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
                   </costs>
+                </entryLink>
+                <entryLink import="true" name="Volkite culverin" hidden="false" id="da59-e24d-2ca3-a1b9" type="selectionEntry" targetId="fcf0-9c1b-d51e-6bc7" sortIndex="6">
                   <modifiers>
                     <modifier type="set" value="Two volkite culverin" field="name"/>
                   </modifiers>
-                </infoLink>
-                <infoLink name="Cyclone missile launcher" id="8a7a-cd98-a6e2-8b3e" hidden="false" type="selectionEntry" targetId="b341-159d-9dfb-ff31" sortIndex="1">
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
                   </costs>
-                  <modifiers>
-                    <modifier type="set" value="1" field="defaultAmount"/>
-                  </modifiers>
-                </infoLink>
-              </infoLinks>
+                </entryLink>
+              </entryLinks>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="476f-cb5a-9710-4a15" includeChildSelections="false"/>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b201-977f-81de-dfc2" includeChildSelections="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eb8b-f6df-0e49-2c97"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0988-d186-9ca6-7724"/>
               </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <infoLinks>
-            <infoLink name="Heavy bolter" id="3a06-a1f8-9085-eda9" hidden="false" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="1">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="caee-6758-fc74-0fe4" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9106-e0a3-24b0-4466" includeChildSelections="false"/>
-              </constraints>
-            </infoLink>
             <infoLink name="Bulky (X)" id="eeac-1e29-2b5c-6c7c" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
               <modifiers>
                 <modifier type="set" value="Bulky (5)" field="name"/>
@@ -11939,6 +11920,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               </modifiers>
             </infoLink>
           </infoLinks>
+          <entryLinks>
+            <entryLink import="true" name="Heavy bolter" hidden="false" id="d0ad-a85a-3fd7-b65b" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="1">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f413-353f-679a-8b31" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2640-b48c-e1a3-63cc" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
@@ -12138,41 +12127,26 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <entryLink import="true" name="Heavy bolter" hidden="false" id="7b28-c20f-774b-26a3" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="1" defaultAmount="1"/>
                 <entryLink import="true" name="Heavy flamer" hidden="false" id="e453-e0f1-829f-2a92" type="selectionEntry" targetId="4fa7-ea45-2a89-ad86" sortIndex="2"/>
                 <entryLink import="true" name="Havoc launcher" hidden="false" id="bf5b-3fad-026a-871d" type="selectionEntry" targetId="0295-e35d-2ed6-f28a" sortIndex="3">
-                  <modifiers>
-                    <modifier type="set" value="5" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Multi-melta" hidden="false" id="6df5-4853-5aa8-30d1" type="selectionEntry" targetId="0135-12f0-d86f-ced9" sortIndex="4">
-                  <modifiers>
-                    <modifier type="set" value="20" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Volkite culverin" hidden="false" id="372c-ef80-63fe-36f6" type="selectionEntry" targetId="fcf0-9c1b-d51e-6bc7" sortIndex="5">
-                  <modifiers>
-                    <modifier type="set" value="5" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Plasma cannon" hidden="false" id="3981-f2b2-573e-2a66" type="selectionEntry" targetId="f8b8-96c8-ba31-faf8" sortIndex="6">
-                  <modifiers>
-                    <modifier type="set" value="10" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Graviton gun" hidden="false" id="22ef-fc76-c0cf-d4c3" type="selectionEntry" targetId="4a06-c55e-a06f-bd0c" sortIndex="7">
-                  <modifiers>
-                    <modifier type="set" value="10" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
                   </costs>
@@ -12190,33 +12164,21 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <entryLink import="true" name="Heavy bolter" hidden="false" id="f8e4-eec6-ab52-46f8" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="3"/>
                 <entryLink import="true" name="Havoc launcher" hidden="false" id="55e5-db90-9068-8d9c" type="selectionEntry" targetId="0295-e35d-2ed6-f28a" sortIndex="4"/>
                 <entryLink import="true" name="Multi-melta" hidden="false" id="735b-40ad-63aa-8cb0" type="selectionEntry" targetId="0135-12f0-d86f-ced9" sortIndex="5">
-                  <modifiers>
-                    <modifier type="set" value="20" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Plasma cannon" hidden="false" id="eb54-1635-95c3-a97a" type="selectionEntry" targetId="f8b8-96c8-ba31-faf8" sortIndex="7">
-                  <modifiers>
-                    <modifier type="set" value="10" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Volkite culverin" hidden="false" id="6ea5-e0e2-fe4c-06ae" type="selectionEntry" targetId="fcf0-9c1b-d51e-6bc7" sortIndex="6">
-                  <modifiers>
-                    <modifier type="set" value="5" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
                   </costs>
                 </entryLink>
                 <entryLink import="true" name="Graviton gun" hidden="false" id="f876-9f8f-b2e4-fa29" type="selectionEntry" targetId="4a06-c55e-a06f-bd0c" sortIndex="8">
-                  <modifiers>
-                    <modifier type="set" value="10" field="9893-c379-920b-8982"/>
-                  </modifiers>
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
                   </costs>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -11835,7 +11835,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Javelin Squadron" hidden="false" id="50f3-fca2-49ab-6de4" sortIndex="62" defaultAmount="1,3">
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Javelin Speeder" hidden="false" id="bcab-d669-63bc-66fd">
+        <selectionEntry type="model" import="true" name="Javelin Speeder" hidden="false" id="bcab-d669-63bc-66fd" publicationId="b905-0414-1057-bb34" page="101">
           <profiles>
             <profile name="Javelin Speeder" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="252d-4948-967b-a247" publicationId="b905-0414-1057-bb34" page="101">
               <characteristics>
@@ -12107,7 +12107,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
       </entryLinks>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Land Speeder Squadron" hidden="false" id="7ebb-cdb2-017e-7c51" sortIndex="63">
+    <selectionEntry type="unit" import="true" name="Land Speeder Squadron" hidden="false" id="7ebb-cdb2-017e-7c51" sortIndex="63" publicationId="b905-0414-1057-bb34" page="102">
       <infoLinks>
         <infoLink name="[Allegiance]" id="e722-9650-c4e7-199b" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
         <infoLink name="[Legiones Astartes]" id="f563-c169-6e77-a795" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="24" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="25" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>
@@ -11858,7 +11858,9 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             </profile>
           </profiles>
           <categoryLinks>
-            <categoryLink targetId="cf96-8891-3f9a-8921" id="b50d-4d88-8a34-1159" primary="false" name="Fast Attack"/>
+            <categoryLink targetId="a073-2d4a-5bed-123e" id="79a4-0115-ae3a-cd59" primary="true" name="Cavalry Model Type"/>
+            <categoryLink targetId="d2d6-5a84-672b-2833" id="81eb-c2ec-e87b-adaa" primary="false" name="Skirmish Model Sub-Type"/>
+            <categoryLink targetId="c504-9dfa-35d3-c98f" id="325f-01ff-42c7-ba69" primary="false" name="Antigrav Model Sub-Type"/>
           </categoryLinks>
           <constraints>
             <constraint type="max" value="3" field="selections" scope="parent" shared="true" id="8e08-b5d8-aa2b-e9aa" includeChildSelections="false"/>
@@ -11870,45 +11872,77 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
           </costs>
           <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange cyclone missile launcher for:" id="fc82-2177-9a0c-2010" hidden="false" sortIndex="1">
+            <selectionEntryGroup name="May exchange cyclone missile launcher for:" id="0374-2b0c-4218-e502" hidden="false" sortIndex="2">
               <infoLinks>
                 <infoLink name="Lascannon" id="88be-6763-9a75-487f" hidden="false" type="selectionEntry" targetId="b6d5-4be2-c37e-2197" sortIndex="4">
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="set" value="Two lascannon" field="name"/>
+                  </modifiers>
                 </infoLink>
                 <infoLink name="Heavy flamer" id="3925-bccb-33e6-7412" hidden="false" type="selectionEntry" targetId="4fa7-ea45-2a89-ad86" sortIndex="2">
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="set" value="Two heavy flamers" field="name"/>
+                  </modifiers>
                 </infoLink>
                 <infoLink name="Heavy bolter" id="98ef-7a9d-a40c-b44b" hidden="false" type="selectionEntry" targetId="bc40-b14a-978e-0232" defaultAmount="2" sortIndex="3">
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="set" value="Two heavy bolters" field="name"/>
+                  </modifiers>
                 </infoLink>
                 <infoLink name="Volkite culverin" id="9142-45c5-f92b-83a1" hidden="false" type="selectionEntry" targetId="fcf0-9c1b-d51e-6bc7" sortIndex="5">
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="set" value="Two volkite culverin" field="name"/>
+                  </modifiers>
                 </infoLink>
                 <infoLink name="Cyclone missile launcher" id="8a7a-cd98-a6e2-8b3e" hidden="false" type="selectionEntry" targetId="b341-159d-9dfb-ff31" sortIndex="1">
                   <costs>
                     <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
                   </costs>
+                  <modifiers>
+                    <modifier type="set" value="1" field="defaultAmount"/>
+                  </modifiers>
                 </infoLink>
               </infoLinks>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="476f-cb5a-9710-4a15" includeChildSelections="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b201-977f-81de-dfc2" includeChildSelections="false"/>
+              </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <infoLinks>
-            <infoLink name="Heavy bolter" id="3a06-a1f8-9085-eda9" hidden="false" type="selectionEntry" targetId="bc40-b14a-978e-0232"/>
+            <infoLink name="Heavy bolter" id="3a06-a1f8-9085-eda9" hidden="false" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="1">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="caee-6758-fc74-0fe4" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9106-e0a3-24b0-4466" includeChildSelections="false"/>
+              </constraints>
+            </infoLink>
+            <infoLink name="Bulky (X)" id="eeac-1e29-2b5c-6c7c" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
+              <modifiers>
+                <modifier type="set" value="Bulky (5)" field="name"/>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Firing Protocols (X)" id="ed31-397e-d59b-ec73" hidden="false" type="rule" targetId="84f2-5a93-c2eb-826f">
+              <modifiers>
+                <modifier type="set" value="Firing Protocols (3)" field="name"/>
+              </modifiers>
+            </infoLink>
           </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
-        <categoryLink targetId="cf96-8891-3f9a-8921" id="0f65-5063-27e0-d544" primary="false" name="Fast Attack"/>
-        <categoryLink targetId="a073-2d4a-5bed-123e" id="eaa3-8ae1-fb68-c185" primary="false" name="Cavalry Model Type"/>
-        <categoryLink targetId="c504-9dfa-35d3-c98f" id="b739-103f-6616-50f6" primary="false" name="Antigrav Model Sub-Type"/>
+        <categoryLink targetId="cf96-8891-3f9a-8921" id="0f65-5063-27e0-d544" primary="true" name="Fast Attack"/>
       </categoryLinks>
       <costs>
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
@@ -11919,6 +11953,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
       <infoLinks>
         <infoLink name="[Allegiance]" id="c76c-f1d9-1efc-81c5" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
         <infoLink name="[Legiones Astartes]" id="cc38-b82a-6383-5972" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
+        <infoLink name="Deep Strike" id="7d15-462a-078f-399d" hidden="false" type="rule" targetId="0553-d06b-52b9-34db"/>
       </infoLinks>
       <entryLinks>
         <entryLink import="true" name="Prime Unit" hidden="false" id="c3fc-4f07-8ce4-025e" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
@@ -12076,17 +12111,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
       <infoLinks>
         <infoLink name="[Allegiance]" id="e722-9650-c4e7-199b" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
         <infoLink name="[Legiones Astartes]" id="f563-c169-6e77-a795" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
-        <infoLink name="Bulky (X)" id="2326-d5e8-dffe-7771" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
-          <modifiers>
-            <modifier type="set" value="Bulky (4)" field="name"/>
-          </modifiers>
-        </infoLink>
         <infoLink name="Deep Strike" id="4655-8f25-a16f-02bc" hidden="false" type="rule" targetId="0553-d06b-52b9-34db"/>
-        <infoLink name="Firing Protocols (X)" id="36b7-8e0c-5f9f-f4bd" hidden="false" type="rule" targetId="84f2-5a93-c2eb-826f">
-          <modifiers>
-            <modifier type="set" value="Firing Protocols (2)" field="name"/>
-          </modifiers>
-        </infoLink>
       </infoLinks>
       <entryLinks>
         <entryLink import="true" name="Prime Unit" hidden="false" id="f124-9001-1c8f-d8b0" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
@@ -12110,32 +12135,47 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           <selectionEntryGroups>
             <selectionEntryGroup name="May exchange heavy bolter for:" id="7c15-a3e9-0d63-b4c1" hidden="false" defaultSelectionEntryId="7b28-c20f-774b-26a3" sortIndex="1">
               <entryLinks>
-                <entryLink import="true" name="Heavy bolter" hidden="false" id="7b28-c20f-774b-26a3" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="1"/>
+                <entryLink import="true" name="Heavy bolter" hidden="false" id="7b28-c20f-774b-26a3" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="1" defaultAmount="1"/>
                 <entryLink import="true" name="Heavy flamer" hidden="false" id="e453-e0f1-829f-2a92" type="selectionEntry" targetId="4fa7-ea45-2a89-ad86" sortIndex="2"/>
                 <entryLink import="true" name="Havoc launcher" hidden="false" id="bf5b-3fad-026a-871d" type="selectionEntry" targetId="0295-e35d-2ed6-f28a" sortIndex="3">
                   <modifiers>
                     <modifier type="set" value="5" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
                 </entryLink>
                 <entryLink import="true" name="Multi-melta" hidden="false" id="6df5-4853-5aa8-30d1" type="selectionEntry" targetId="0135-12f0-d86f-ced9" sortIndex="4">
                   <modifiers>
                     <modifier type="set" value="20" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                  </costs>
                 </entryLink>
                 <entryLink import="true" name="Volkite culverin" hidden="false" id="372c-ef80-63fe-36f6" type="selectionEntry" targetId="fcf0-9c1b-d51e-6bc7" sortIndex="5">
                   <modifiers>
                     <modifier type="set" value="5" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
                 </entryLink>
-                <entryLink import="true" name="Plasma cannon" hidden="false" id="3981-f2b2-573e-2a66" type="selectionEntry" targetId="f8b8-96c8-ba31-faf8" sortIndex="5">
+                <entryLink import="true" name="Plasma cannon" hidden="false" id="3981-f2b2-573e-2a66" type="selectionEntry" targetId="f8b8-96c8-ba31-faf8" sortIndex="6">
                   <modifiers>
                     <modifier type="set" value="10" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                  </costs>
                 </entryLink>
-                <entryLink import="true" name="Graviton gun" hidden="false" id="22ef-fc76-c0cf-d4c3" type="selectionEntry" targetId="4a06-c55e-a06f-bd0c" sortIndex="6">
+                <entryLink import="true" name="Graviton gun" hidden="false" id="22ef-fc76-c0cf-d4c3" type="selectionEntry" targetId="4a06-c55e-a06f-bd0c" sortIndex="7">
                   <modifiers>
                     <modifier type="set" value="10" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                  </costs>
                 </entryLink>
               </entryLinks>
               <constraints>
@@ -12143,9 +12183,9 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="01c2-2f24-1689-ba1a"/>
               </constraints>
             </selectionEntryGroup>
-            <selectionEntryGroup name="May exchange augury scanner for:" id="cd1b-78e1-fd27-1192" hidden="false" defaultSelectionEntryId="c8d8-b2a5-154a-1e65">
+            <selectionEntryGroup name="May exchange augury scanner for:" id="cd1b-78e1-fd27-1192" hidden="false" defaultSelectionEntryId="c8d8-b2a5-154a-1e65" sortIndex="2">
               <entryLinks>
-                <entryLink import="true" name="Augury scanner" hidden="false" id="c8d8-b2a5-154a-1e65" type="selectionEntry" targetId="fede-99f5-4c76-4659" sortIndex="1"/>
+                <entryLink import="true" name="Augury scanner" hidden="false" id="c8d8-b2a5-154a-1e65" type="selectionEntry" targetId="fede-99f5-4c76-4659" sortIndex="1" defaultAmount="1"/>
                 <entryLink import="true" name="Heavy flamer" hidden="false" id="808f-79a3-7358-e7c1" type="selectionEntry" targetId="4fa7-ea45-2a89-ad86" sortIndex="2"/>
                 <entryLink import="true" name="Heavy bolter" hidden="false" id="f8e4-eec6-ab52-46f8" type="selectionEntry" targetId="bc40-b14a-978e-0232" sortIndex="3"/>
                 <entryLink import="true" name="Havoc launcher" hidden="false" id="55e5-db90-9068-8d9c" type="selectionEntry" targetId="0295-e35d-2ed6-f28a" sortIndex="4"/>
@@ -12153,21 +12193,33 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <modifiers>
                     <modifier type="set" value="20" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                  </costs>
                 </entryLink>
                 <entryLink import="true" name="Plasma cannon" hidden="false" id="eb54-1635-95c3-a97a" type="selectionEntry" targetId="f8b8-96c8-ba31-faf8" sortIndex="7">
                   <modifiers>
                     <modifier type="set" value="10" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                  </costs>
                 </entryLink>
                 <entryLink import="true" name="Volkite culverin" hidden="false" id="6ea5-e0e2-fe4c-06ae" type="selectionEntry" targetId="fcf0-9c1b-d51e-6bc7" sortIndex="6">
                   <modifiers>
                     <modifier type="set" value="5" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
                 </entryLink>
                 <entryLink import="true" name="Graviton gun" hidden="false" id="f876-9f8f-b2e4-fa29" type="selectionEntry" targetId="4a06-c55e-a06f-bd0c" sortIndex="8">
                   <modifiers>
                     <modifier type="set" value="10" field="9893-c379-920b-8982"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                  </costs>
                 </entryLink>
               </entryLinks>
               <constraints>
@@ -12175,9 +12227,13 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5e6b-a1ca-7656-b0d6"/>
               </constraints>
             </selectionEntryGroup>
-            <selectionEntryGroup name="Option" id="c1b4-e6be-fe62-422a" hidden="false">
+            <selectionEntryGroup name="Additional Wargear" id="c1b4-e6be-fe62-422a" hidden="false" sortIndex="3">
               <entryLinks>
-                <entryLink import="true" name="Hunter-killer missile" hidden="false" id="a044-c312-1eda-2f4a" type="selectionEntry" targetId="b9b7-8297-35b5-74ad"/>
+                <entryLink import="true" name="Hunter-killer missile" hidden="false" id="a044-c312-1eda-2f4a" type="selectionEntry" targetId="b9b7-8297-35b5-74ad">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
               <constraints>
                 <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="93bf-8e9f-93e5-28fc"/>
@@ -12205,13 +12261,27 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               </characteristics>
             </profile>
           </profiles>
+          <categoryLinks>
+            <categoryLink targetId="a073-2d4a-5bed-123e" id="885d-b5ed-49b1-9bbf" primary="true" name="Cavalry Model Type"/>
+            <categoryLink targetId="c504-9dfa-35d3-c98f" id="c086-3964-945d-8a41" primary="false" name="Antigrav Model Sub-Type"/>
+            <categoryLink targetId="d2d6-5a84-672b-2833" id="7314-ef60-2436-8a5c" primary="false" name="Skirmish Model Sub-Type"/>
+          </categoryLinks>
+          <infoLinks>
+            <infoLink name="Bulky (X)" id="2326-d5e8-dffe-7771" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
+              <modifiers>
+                <modifier type="set" value="Bulky (4)" field="name"/>
+              </modifiers>
+            </infoLink>
+            <infoLink name="Firing Protocols (X)" id="36b7-8e0c-5f9f-f4bd" hidden="false" type="rule" targetId="84f2-5a93-c2eb-826f">
+              <modifiers>
+                <modifier type="set" value="Firing Protocols (2)" field="name"/>
+              </modifiers>
+            </infoLink>
+          </infoLinks>
         </selectionEntry>
       </selectionEntries>
       <categoryLinks>
         <categoryLink targetId="cf96-8891-3f9a-8921" id="64fb-df27-5ed8-d47d" primary="true" name="Fast Attack"/>
-        <categoryLink targetId="a073-2d4a-5bed-123e" id="188a-cd8e-71bd-056b" primary="false" name="Cavalry Model Type"/>
-        <categoryLink targetId="d2d6-5a84-672b-2833" id="e311-12c1-8018-f824" primary="false" name="Skirmish Model Sub-Type"/>
-        <categoryLink targetId="c504-9dfa-35d3-c98f" id="44ba-e034-efba-1138" primary="false" name="Antigrav Model Sub-Type"/>
       </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Sicaran" hidden="false" id="4d65-cef9-42c6-dd2c" sortIndex="65">


### PR DESCRIPTION
Fixes to the Javelin Squadron and the Land Speeder Squadron. This replaces half of #530 and #651 . It also fixes issues introduced in #90. 

The Javelin had to be nearly completely remade due to some kind of bug with the selection group and heavy bolter not being displayed correctly.

The Land Speeder needed its points change to be set normally and not with modifiers (which it was for some reason). It also had minor cosmetic and category reorganization to match others.

<img width="1197" height="779" alt="image" src="https://github.com/user-attachments/assets/72f77ce6-6359-4a22-a45a-b81386c1158f" />

<img width="1197" height="779" alt="image" src="https://github.com/user-attachments/assets/c69b7dfd-3a7b-47f5-8c28-730b046bff6c" />
