### PR TITLE
SA - Iron Tercio added

### DIFF
--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="28" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="29" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <categoryEntries>
     <categoryEntry name="Officer of the Line (2)" id="901a-6b71-7a29-4597" hidden="false"/>
     <categoryEntry name="Allegiance" id="c408-52f1-b632-4c82" hidden="false"/>
@@ -201,7 +201,7 @@
           <description>The following Rules apply to all Models with the Malefic Sub-Type:
 • When a Unit composed entirely of Models with the Malefic Sub-Type would gain a Tactical Status of any kind, that Tactical Status is not applied to the Models in the Unit, but instead the Unit suffers D3 automatic wounds with an AP of 2 and a Damage Characteristic of 1 against which no Saving Throws of any kind may be made. Once these wounds are resolved, no Tactical Status is applied to any Model in the Unit.
 • Models with the Malefic Sub-Type are not affected by Special Rules that negatively modify their Leadership, Cool, Willpower or Intelligence Characteristics.
-• No Model that does not also have the Malefic Sub-Type may join or be joined by a Unit that includes one or more Models with the Malefic Sub-Type. </description>
+• No Model that does not also have the Malefic Sub-Type may join or be joined by a Unit that includes one or more Models with the Malefic Sub-Type.</description>
         </rule>
       </rules>
     </categoryEntry>
@@ -283,6 +283,15 @@
     <categoryEntry name="Support - Rapier Section, Basilisk Artillery Tank or Medusa Artillery tank units only" id="ada1-aac4-9802-9c3d" hidden="false"/>
     <categoryEntry name="Armour - Leman Russ Strike, Leman Russ Assault or Malcador Heavy tank units only" id="5725-7f8c-f02e-4df6" hidden="false"/>
     <categoryEntry name="War-engine - Aethon Heavy Sentinel Squadron units only" id="5ee3-236d-c224-67aa" hidden="false"/>
+    <categoryEntry name="Heavy Assault - Castellax Destructor Maniple only " id="d49e-048b-a8e2-ba52" hidden="false">
+      <comment>Solar Auxilia - Iron Tercio</comment>
+    </categoryEntry>
+    <categoryEntry name="Troops - Tech-Priest unit only" id="3fda-dd8a-a6d5-b782" hidden="false">
+      <comment>Solar Auxilia - Iron Tercio</comment>
+    </categoryEntry>
+    <categoryEntry name="Support - Castellax Battle Maniple or Thallax Cohort Unit only" id="0fd5-6d2d-e2cc-d22a" hidden="false">
+      <comment>Solar Auxilia - Iron Tercio</comment>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry name="Crusade Force Organization Chart" id="8562-592c-8d4b-a1f0" hidden="false" childForcesLabel="Detachments" sortIndex="1">
@@ -11639,18 +11648,18 @@
         </forceEntry>
         <forceEntry name="Auxiliary - Iron Tercio" id="9a10-a2d9-5a87-a5a9" hidden="true" sortIndex="35">
           <categoryLinks>
-            <categoryLink name="Troops" hidden="false" id="13dd-708a-30bc-4c72" targetId="88e6-d373-4152-0dd8">
+            <categoryLink name="Auxiliary Detachment" hidden="false" id="9939-ad32-7608-7ad1" targetId="1a65-8b23-419b-b30f"/>
+            <categoryLink name="Troops - Tech-Priest unit only" hidden="false" id="c907-0af7-cce9-9ba8" targetId="3fda-dd8a-a6d5-b782" type="categoryEntry">
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b57b-c01a-64d4-dd3c" includeChildSelections="false"/>
               </constraints>
             </categoryLink>
-            <categoryLink name="Auxiliary Detachment" hidden="false" id="9939-ad32-7608-7ad1" targetId="1a65-8b23-419b-b30f"/>
-            <categoryLink name="Support" hidden="false" id="84a6-92e2-1afd-8497" targetId="345f-9ba6-9b02-ed5c">
+            <categoryLink name="Support - Castellax Battle Maniple or Thallax Cohort Unit only" hidden="false" id="0599-b368-516c-e9d6" targetId="0fd5-6d2d-e2cc-d22a" type="categoryEntry">
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7143-e998-ba72-8b90"/>
               </constraints>
             </categoryLink>
-            <categoryLink name="Heavy Assault" hidden="false" id="828a-d1ae-eaee-d2b7" targetId="3235-bd79-e9b1-60fa">
+            <categoryLink name="Heavy Assault - Castellax Destructor Maniple only " hidden="false" id="5f2c-c81c-7da0-c8cd" targetId="d49e-048b-a8e2-ba52" type="categoryEntry">
               <constraints>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c24e-c0f6-4c76-42e0"/>
               </constraints>
@@ -11679,6 +11688,11 @@
           <constraints>
             <constraint type="max" value="0" field="forces" scope="roster" shared="true" id="f66f-803d-5433-bb35" includeChildSelections="true"/>
           </constraints>
+          <rules>
+            <rule name="Iron Tercio" id="d67e-d02f-4598-ed8a" hidden="false">
+              <description>Units selected as part of this Detachment which contains both one or more Tech-priests and one or more Models with the Automata Type may Hold, Control and Contest Objectives. </description>
+            </rule>
+          </rules>
         </forceEntry>
       </forceEntries>
       <constraints>

--- a/Mech Library.cat
+++ b/Mech Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="a159-1624-dbac-7af8" name="Mech Library" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="2" revision="3" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="a159-1624-dbac-7af8" name="Mech Library" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="2" revision="4" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Maxima bolter" hidden="false" id="350a-3713-d175-ab09">
       <profiles>
@@ -1196,6 +1196,11 @@
         <modifier type="set" value="Macrotek" field="name">
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1ec3-1433-658a-f04e" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditions>
+            <condition type="notInstanceOf" value="1" field="selections" scope="primary-catalogue" childId="2f57-6e9d-8a7b-5c2e" shared="true"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Solar Auxilia.cat
+++ b/Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7851-69ac-f701-034e" name="Solar Auxilia" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="16" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7851-69ac-f701-034e" name="Solar Auxilia" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="17" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" hidden="true">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Legatine Command Section" hidden="false" id="8641-1dd0-7e76-de7d">
       <categoryLinks>
@@ -6055,6 +6055,7 @@ Payer&apos;s Movement Phase continues, starting wit m performing a Fall Back Mov
     <catalogueLink type="catalogue" name="Assets" id="b5e6-724c-cef8-8313" targetId="5334-5605-242c-d75e"/>
     <catalogueLink type="catalogue" name="Wargear" id="acc0-5e1b-7a02-ecb9" targetId="fcc7-4319-bb04-2c25"/>
     <catalogueLink type="catalogue" name="Weapons" id="9a74-63aa-a3e1-2932" targetId="a22d-4dd0-c59d-57d3"/>
+    <catalogueLink type="catalogue" name="Mechanicum" id="201c-843f-13db-028e" targetId="2f57-6e9d-8a7b-5c2e"/>
   </catalogueLinks>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Auxilia Pistols" id="22a3-5b09-13b0-2624" hidden="false">
@@ -6807,5 +6808,44 @@ Payer&apos;s Movement Phase continues, starting wit m performing a Fall Back Mov
         <categoryLink targetId="abfa-86ab-1726-077a" id="1691-badf-2b47-e042" primary="true" name="Army Configuration"/>
       </categoryLinks>
     </entryLink>
+    <entryLink import="true" name="Castellax Destructor Maniple" hidden="false" id="a092-1535-541e-22e8" type="selectionEntry" targetId="112f-1168-d07c-7f8f">
+      <categoryLinks>
+        <categoryLink targetId="d49e-048b-a8e2-ba52" id="e430-9e8a-68c0-ef30" primary="true" name="Heavy Assault - Castellax Destructor Maniple only "/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Iron Tercio" id="1091-dc9e-7845-6b2b" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+      </infoLinks>
+    </entryLink>
+    <entryLink import="true" name="Tech-Priest" hidden="false" id="2961-1167-7a69-c00b" type="selectionEntry" targetId="bc86-4606-7fce-1866">
+      <categoryLinks>
+        <categoryLink targetId="3fda-dd8a-a6d5-b782" id="8aab-5e50-8ee4-7f9f" primary="true" name="Troops - Tech-Priest unit only"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Iron Tercio" id="7cd1-4fad-3bbb-91da" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+      </infoLinks>
+    </entryLink>
+    <entryLink import="true" name="Castellax Battle Maniple" hidden="false" id="a54f-f940-8383-207d" type="selectionEntry" targetId="e8d6-2ba5-d10d-d617">
+      <categoryLinks>
+        <categoryLink targetId="0fd5-6d2d-e2cc-d22a" id="01c1-bdd7-21d3-6224" primary="true" name="Support - Castellax Battle Maniple or Thallax Cohort Unit only"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Iron Tercio" id="f25b-0cc8-7e9c-071c" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+      </infoLinks>
+    </entryLink>
+    <entryLink import="true" name="Thallax Cohort" hidden="false" id="9417-4cb5-a16c-86b9" type="selectionEntry" targetId="a4ad-1b49-0303-59b3">
+      <categoryLinks>
+        <categoryLink targetId="0fd5-6d2d-e2cc-d22a" id="b6cb-1431-9b31-7fea" primary="true" name="Support - Castellax Battle Maniple or Thallax Cohort Unit only"/>
+      </categoryLinks>
+      <infoLinks>
+        <infoLink name="Iron Tercio" id="bb63-99e3-8620-9719" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+      </infoLinks>
+    </entryLink>
   </entryLinks>
+  <sharedProfiles>
+    <profile name="Iron Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="0c69-af93-68ac-7aa6">
+      <characteristics>
+        <characteristic name="Description" typeId="d5eb-0b8b-0f26-6233"/>
+      </characteristics>
+    </profile>
+  </sharedProfiles>
 </catalogue>


### PR DESCRIPTION
Iron Tercio added and import links for Mechanicum units. Set Mechanicum traits in mech catalogue to hide if not Primary Catalogue of Mechanicum so they would not show in Praevian and Iron Tercio.