### PR TITLE
Update to make Doctrines work Correctly, Fix Iron Tercio Trait

### DIFF
--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="38" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="39" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <categoryEntries>
     <categoryEntry name="Officer of the Line (2)" id="901a-6b71-7a29-4597" hidden="false"/>
     <categoryEntry name="Allegiance" id="c408-52f1-b632-4c82" hidden="false"/>
@@ -6736,6 +6736,7 @@
                 <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="aa68-7c65-5d9f-280f"/>
               </constraints>
             </categoryLink>
+            <categoryLink name="Cohort Doctrine: Solar Pattern Cohort" hidden="false" id="833b-b51d-5db3-570a" targetId="f2be-abfe-311c-afe2" type="categoryEntry"/>
           </categoryLinks>
           <modifiers>
             <modifier type="set" value="false" field="hidden">
@@ -6759,11 +6760,16 @@
             </modifier>
             <modifier type="increment" value="2" field="0cdf-ec44-4886-b292">
               <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="roster" childId="f2be-abfe-311c-afe2" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="equalTo" value="1" field="selections" scope="roster" childId="f2be-abfe-311c-afe2" shared="true" includeChildSelections="true" includeChildForces="true"/>
               </conditions>
               <repeats>
                 <repeat value="1" repeats="1" field="selections" scope="roster" childId="67d3-556b-b619-28e2" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
               </repeats>
+            </modifier>
+            <modifier type="set" value="0.5" field="3e8e-05ee-be52-12d6">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="roster" childId="f2be-abfe-311c-afe2" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
             </modifier>
           </modifiers>
           <comment>SA Only</comment>
@@ -6819,6 +6825,11 @@
                 <repeat value="1" repeats="1" field="selections" scope="roster" childId="390f-d9dc-10d8-56aa" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
               </repeats>
             </modifier>
+            <modifier type="set" value="0.5" field="3e8e-05ee-be52-12d6">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="roster" childId="1d7a-eb2d-5d0f-0fa4" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <comment>SA Only</comment>
           <constraints>
@@ -6872,6 +6883,11 @@
               <repeats>
                 <repeat value="1" repeats="1" field="selections" scope="roster" childId="2a0c-b2b2-0f48-2e90" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
               </repeats>
+            </modifier>
+            <modifier type="set" value="0.5" field="3e8e-05ee-be52-12d6">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="roster" childId="c9ef-b204-e951-6b7e" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
             </modifier>
           </modifiers>
           <comment>SA Only</comment>
@@ -7128,6 +7144,11 @@
                 <repeat value="1" repeats="1" field="selections" scope="roster" childId="847c-d351-32a7-cc2a" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
               </repeats>
             </modifier>
+            <modifier type="set" value="0.5" field="3e8e-05ee-be52-12d6">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="roster" childId="1241-4ccd-80b8-8ff2" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <comment>SA Only</comment>
           <constraints>
@@ -7191,6 +7212,11 @@
               <repeats>
                 <repeat value="1" repeats="1" field="selections" scope="roster" childId="3bba-e8bb-7463-b0b2" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
               </repeats>
+            </modifier>
+            <modifier type="set" value="0.5" field="3e8e-05ee-be52-12d6">
+              <conditions>
+                <condition type="equalTo" value="1" field="selections" scope="roster" childId="7f98-e8eb-f86e-180d" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
             </modifier>
           </modifiers>
           <comment>SA Only</comment>
@@ -13643,11 +13669,6 @@
         <modifier type="increment" value="1" field="0ab6-91a0-792e-4068">
           <repeats>
             <repeat value="1" repeats="1" field="selections" scope="force" childId="ff44-f49f-732b-c3a7" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
-          </repeats>
-        </modifier>
-        <modifier type="increment" value="1" field="0ab6-91a0-792e-4068">
-          <repeats>
-            <repeat value="1" repeats="1" field="selections" scope="force" childId="27e8-88b4-d3c8-d63f" shared="true" roundUp="false" includeChildSelections="true" includeChildForces="true"/>
           </repeats>
         </modifier>
       </modifiers>

--- a/Solar Auxilia.cat
+++ b/Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7851-69ac-f701-034e" name="Solar Auxilia" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="17" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7851-69ac-f701-034e" name="Solar Auxilia" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="18" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Legatine Command Section" hidden="false" id="8641-1dd0-7e76-de7d">
       <categoryLinks>
@@ -586,7 +586,6 @@
       <categoryLinks>
         <categoryLink targetId="594d-fa82-13cb-a345" id="ef26-0330-2289-5503" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="847c-d351-32a7-cc2a" id="4686-b7ef-e522-6efd" primary="false" name="Infantry Tercio Unlock"/>
-        <categoryLink targetId="27e8-88b4-d3c8-d63f" id="fdcd-cd9e-a1ef-bacb" primary="false" name="Cohort Additional Detachment"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Troop Master" hidden="false" id="3b35-940c-5f39-b55b" sortIndex="1">
@@ -896,7 +895,6 @@
       <categoryLinks>
         <categoryLink targetId="594d-fa82-13cb-a345" id="1a58-a45d-104d-6e12" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="67d3-556b-b619-28e2" id="3334-9e7a-7b9e-5dcb" primary="false" name="Veletaris Tercio Unlock"/>
-        <categoryLink targetId="27e8-88b4-d3c8-d63f" id="0b7f-348d-d476-01b8" primary="false" name="Cohort Additional Detachment"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="First Prime" hidden="false" id="41f2-b11e-6a6e-a1c7" sortIndex="1">
@@ -1163,7 +1161,6 @@
         <categoryLink targetId="a073-2d4a-5bed-123e" id="dc64-10c5-13ba-4141" primary="false" name="Cavalry Model Type"/>
         <categoryLink targetId="f4ba-00e5-3d2e-eaac" id="5352-158a-e9a0-c0aa" primary="false" name="Light Model Sub-Type"/>
         <categoryLink targetId="3bba-e8bb-7463-b0b2" id="12c6-455b-8885-c917" primary="false" name="Scout Tercio Unlock"/>
-        <categoryLink targetId="27e8-88b4-d3c8-d63f" id="d582-6fe4-b453-4cce" primary="false" name="Cohort Additional Detachment"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Hermes Lead" hidden="false" id="ffde-524f-3179-76a8" sortIndex="1">
@@ -1364,7 +1361,6 @@
       <categoryLinks>
         <categoryLink targetId="594d-fa82-13cb-a345" id="e7c9-6ae8-36fc-0fcd" primary="false" name="Infantry Model Type"/>
         <categoryLink targetId="2a0c-b2b2-0f48-2e90" id="5f78-a662-696e-f5f1" primary="false" name="Artillery Tercio Unlock"/>
-        <categoryLink targetId="27e8-88b4-d3c8-d63f" id="36e8-b96c-3a31-382b" primary="false" name="Cohort Additional Detachment"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Ordnance Master" hidden="false" id="7b90-c809-7792-10b5" sortIndex="1">
@@ -1694,7 +1690,6 @@
       <categoryLinks>
         <categoryLink targetId="aa5a-c9fd-1eb1-7a45" id="725d-ae0a-7669-c86c" primary="false" name="Vehicle Model Type"/>
         <categoryLink targetId="390f-d9dc-10d8-56aa" id="31dd-800c-470f-9f47" primary="false" name="Armour Tercio Unlock"/>
-        <categoryLink targetId="27e8-88b4-d3c8-d63f" id="2edd-50c9-56d9-2e53" primary="false" name="Cohort Additional Detachment"/>
       </categoryLinks>
       <profiles>
         <profile name="Solar Auxilia" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="e678-ce42-91de-edfc">
@@ -6814,7 +6809,7 @@ Payer&apos;s Movement Phase continues, starting wit m performing a Fall Back Mov
         <categoryLink targetId="3235-bd79-e9b1-60fa" id="96a9-a9b8-a06a-b6ea" primary="true" name="Heavy Assault"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Iron Tercio" id="1091-dc9e-7845-6b2b" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+        <infoLink name="Iron Tercio" id="1091-dc9e-7845-6b2b" hidden="false" type="profile" targetId="fd91-cc08-8aa0-7d8a"/>
       </infoLinks>
       <modifiers>
         <modifier type="set-primary" value="d49e-048b-a8e2-ba52" field="category"/>
@@ -6825,7 +6820,7 @@ Payer&apos;s Movement Phase continues, starting wit m performing a Fall Back Mov
         <categoryLink targetId="88e6-d373-4152-0dd8" id="5cbe-001a-b4cd-92bd" primary="true" name="Troops"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Iron Tercio" id="7cd1-4fad-3bbb-91da" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+        <infoLink name="Iron Tercio" id="7cd1-4fad-3bbb-91da" hidden="false" type="profile" targetId="fd91-cc08-8aa0-7d8a"/>
       </infoLinks>
       <modifiers>
         <modifier type="set-primary" value="3fda-dd8a-a6d5-b782" field="category"/>
@@ -6836,7 +6831,7 @@ Payer&apos;s Movement Phase continues, starting wit m performing a Fall Back Mov
         <categoryLink targetId="345f-9ba6-9b02-ed5c" id="5e54-5bf2-00fd-20ad" primary="true" name="Support"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Iron Tercio" id="f25b-0cc8-7e9c-071c" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+        <infoLink name="Iron Tercio" id="f25b-0cc8-7e9c-071c" hidden="false" type="profile" targetId="fd91-cc08-8aa0-7d8a"/>
       </infoLinks>
       <modifiers>
         <modifier type="set-primary" value="0fd5-6d2d-e2cc-d22a" field="category"/>
@@ -6847,7 +6842,7 @@ Payer&apos;s Movement Phase continues, starting wit m performing a Fall Back Mov
         <categoryLink targetId="345f-9ba6-9b02-ed5c" id="3acc-69fc-ac86-e802" primary="true" name="Support"/>
       </categoryLinks>
       <infoLinks>
-        <infoLink name="Iron Tercio" id="bb63-99e3-8620-9719" hidden="false" type="profile" targetId="0c69-af93-68ac-7aa6"/>
+        <infoLink name="Iron Tercio" id="bb63-99e3-8620-9719" hidden="false" type="profile" targetId="fd91-cc08-8aa0-7d8a"/>
       </infoLinks>
       <modifiers>
         <modifier type="set-primary" value="0fd5-6d2d-e2cc-d22a" field="category"/>
@@ -6855,14 +6850,32 @@ Payer&apos;s Movement Phase continues, starting wit m performing a Fall Back Mov
     </entryLink>
   </entryLinks>
   <sharedProfiles>
-    <profile name="Iron Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="0c69-af93-68ac-7aa6">
+    <profile name="Iron Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="fd91-cc08-8aa0-7d8a">
+      <characteristics>
+        <characteristic name="Description" typeId="d5eb-0b8b-0f26-6233">Iron Tercio</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Veletaris Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="a23e-cf3c-ed29-eb15">
       <characteristics>
         <characteristic name="Description" typeId="d5eb-0b8b-0f26-6233"/>
       </characteristics>
     </profile>
-  </sharedProfiles>
-  <sharedProfiles>
-    <profile name="Iron Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="0c69-af93-68ac-7aa6">
+    <profile name="Infantry Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="66b0-bc92-d561-2065">
+      <characteristics>
+        <characteristic name="Description" typeId="d5eb-0b8b-0f26-6233">Iron Tercio</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Artillery Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="7163-444e-d23f-d7ea">
+      <characteristics>
+        <characteristic name="Description" typeId="d5eb-0b8b-0f26-6233"/>
+      </characteristics>
+    </profile>
+    <profile name="Scout Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="2ce2-731c-5355-1b42">
+      <characteristics>
+        <characteristic name="Description" typeId="d5eb-0b8b-0f26-6233"/>
+      </characteristics>
+    </profile>
+    <profile name="Armour Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="3d6a-a668-56c6-ff60">
       <characteristics>
         <characteristic name="Description" typeId="d5eb-0b8b-0f26-6233"/>
       </characteristics>


### PR DESCRIPTION
<img width="567" height="487" alt="image" src="https://github.com/user-attachments/assets/ff038e47-a792-40f4-a794-f140a2b234f8" />

When appropriate Doctrine is selected, the Auxiliary Detachment Cost becomes .5, allowing the user to select 2 Detachments to fill one slot. This seems to work the best, and actually work. 
Fixes #838

I also fixed the Iron Tercio Trait to link to a trait. 