### PR TITLE
Fix for Salamander getting all mech stuff

### DIFF
--- a/Salamanders.cat
+++ b/Salamanders.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="f148-a6e4-5a8c-3aeb" name="                        XVIII - Salamanders" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="9" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="f148-a6e4-5a8c-3aeb" name="                        XVIII - Salamanders" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="10" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Firedrake Terminator Squad" hidden="false" id="09a9-6c68-9b0b-f24f" sortIndex="2">
       <selectionEntries>
@@ -1414,7 +1414,6 @@ effects of the Limited (X) Special Rule when making Volley Attacks.</description
     <catalogueLink type="catalogue" name="Traits" id="9765-ed19-5f07-d757" targetId="df17-7a05-0826-6e22"/>
     <catalogueLink type="catalogue" name="Special Rules" id="383b-24b7-e007-befb" targetId="106b-693b-99f2-00c3"/>
     <catalogueLink type="catalogue" name="Weapons" id="ee7a-856f-787a-e488" targetId="a22d-4dd0-c59d-57d3"/>
-    <catalogueLink type="catalogue" name="Mechanicum" id="cf04-067d-a297-9156" targetId="2f57-6e9d-8a7b-5c2e" importRootEntries="true"/>
   </catalogueLinks>
   <entryLinks>
     <entryLink import="true" name="Vulkan" hidden="false" id="0c0e-fb2f-fb1e-d771" type="selectionEntry" targetId="29d9-3ea2-0c2b-5c36" sortIndex="1">


### PR DESCRIPTION
Removed the link to Mech which seems to have been added by mistake as it is also included in LA cat.