### PR TITLE
Fix Scout Tercio Unlock

### DIFF
--- a/Solar Auxilia.cat
+++ b/Solar Auxilia.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7851-69ac-f701-034e" name="Solar Auxilia" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="26" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="7851-69ac-f701-034e" name="Solar Auxilia" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="27" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Legatine Command Section" hidden="false" id="8641-1dd0-7e76-de7d">
       <selectionEntries>
@@ -1611,6 +1611,9 @@
         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
+      <categoryLinks>
+        <categoryLink targetId="3bba-e8bb-7463-b0b2" id="1fe8-38ae-b078-2069" primary="false" name="Scout Tercio Unlock"/>
+      </categoryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Artillery Command Section" hidden="false" id="4986-b408-cbfe-2d2f">
       <categoryLinks>
@@ -4161,9 +4164,6 @@
               </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <entryLinks>
-            <entryLink import="true" name="Prime Unit" hidden="false" id="396b-a702-2c49-ef90" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2" sortIndex="3"/>
-          </entryLinks>
           <categoryLinks>
             <categoryLink targetId="38d4-d720-8009-acd3" id="c559-ce7a-4740-a0a7" primary="false" name="Walker Model Type"/>
             <categoryLink targetId="d2d6-5a84-672b-2833" id="3740-dca9-49cf-baf2" primary="false" name="Skirmish Model Sub-Type"/>


### PR DESCRIPTION
Missing category on Hermes command section

Fixes #1039

<img width="1168" height="616" alt="image" src="https://github.com/user-attachments/assets/06ea9203-33fa-46ff-9eaf-13b5e486e5bb" />

Also removed second redundant Prime Benefits sseg in Aethoun Squadron