### PR TITLE
Fix Infantry Tercio LB slots

### DIFF
--- a/Dark Angels.cat
+++ b/Dark Angels.cat
@@ -887,7 +887,6 @@
           </modifiers>
         </infoLink>
         <infoLink name="[Allegiance]" id="bc1b-06f7-8e3d-231f" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
-        <infoLink name="Heavy Unit Sub-type" id="c4ab-c0b7-99b3-c8d4" hidden="false" type="rule" targetId="7d35-4d6f-c4fe-4aac"/>
         <infoLink name="The Angels of Death" id="7dfc-ac5a-0adb-29aa" hidden="false" type="rule" targetId="7fd2-c16b-0e15-9de7"/>
       </infoLinks>
       <rules>
@@ -1179,7 +1178,6 @@ The Lion&apos;s Choler: If this Gambit is selected, the Model for which this Gam
               </modifiers>
               <comment>2</comment>
             </infoLink>
-            <infoLink name="Heavy Unit Sub-type" id="8a49-43c2-2026-0ccc" hidden="false" type="rule" targetId="7d35-4d6f-c4fe-4aac"/>
             <infoLink name="Implacable Advance" id="0c0f-e8e0-89dd-ed09" hidden="false" type="rule" targetId="3898-aafb-35e0-141b"/>
             <infoLink name="Slow and Purposeful" id="be28-dbe5-9b77-dd6b" hidden="false" type="rule" targetId="6a8e-e508-abc9-cb3e"/>
             <infoLink name="The Angels of Death" id="6676-3944-6317-a19e" hidden="false" type="rule" targetId="7fd2-c16b-0e15-9de7"/>
@@ -2381,7 +2379,6 @@ The Lion&apos;s Choler: If this Gambit is selected, the Model for which this Gam
           </modifiers>
         </infoLink>
         <infoLink name="[Allegiance]" id="0c81-e19f-3138-119a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
-        <infoLink name="Heavy Unit Sub-type" id="7081-6777-e6c7-1d2b" hidden="false" type="rule" targetId="7d35-4d6f-c4fe-4aac"/>
         <infoLink name="The Angels of Death" id="a221-f54a-7297-6c7f" hidden="false" type="rule" targetId="7fd2-c16b-0e15-9de7"/>
       </infoLinks>
       <rules>

--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="49" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="sys-9fe4-1dc3-b7c2-73cf" name="Horus Heresy 3rd Edition" battleScribeVersion="2.03" revision="50" type="gameSystem" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <categoryEntries>
     <categoryEntry name="Officer of the Line (2)" id="901a-6b71-7a29-4597" hidden="false"/>
     <categoryEntry name="Allegiance" id="c408-52f1-b632-4c82" hidden="false"/>
@@ -10320,23 +10320,6 @@
                 <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="7dd9-c270-75c3-8e1f" includeChildSelections="true"/>
               </constraints>
             </categoryLink>
-            <categoryLink name="Recon" hidden="false" id="26bf-06ed-c37e-c1f5" targetId="2b65-a3f2-620a-dc58">
-              <constraints>
-                <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="0754-a130-acc6-e5ec"/>
-              </constraints>
-              <modifiers>
-                <modifier type="increment" value="1" field="0754-a130-acc6-e5ec">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="force" childId="a166-27df-d75c-bdb0" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="equalTo" value="0" field="selections" scope="force" childId="a166-27df-d75c-bdb0" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </categoryLink>
             <categoryLink name="Prime Recon" hidden="false" id="71d6-78d1-8b85-915d" targetId="6348-ecd0-714d-042a">
               <constraints>
                 <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="addd-962c-6265-3b3e" includeChildSelections="true"/>
@@ -10372,6 +10355,23 @@
                 <modifier type="set" value="true" field="hidden">
                   <conditions>
                     <condition type="equalTo" value="0" field="selections" scope="force" childId="18ed-afc2-ec5d-9f8c" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </categoryLink>
+            <categoryLink name="Elites" hidden="false" id="ca08-7844-7c7b-61d9" targetId="5d5e-958f-e388-50b5">
+              <constraints>
+                <constraint type="max" value="0" field="selections" scope="parent" shared="true" id="ad1d-4f49-e2d8-b4f8"/>
+              </constraints>
+              <modifiers>
+                <modifier type="increment" value="1" field="ad1d-4f49-e2d8-b4f8">
+                  <conditions>
+                    <condition type="equalTo" value="1" field="selections" scope="force" childId="d81c-494b-0302-5844" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="equalTo" value="0" field="selections" scope="force" childId="d81c-494b-0302-5844" shared="true" includeChildSelections="true"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -19196,19 +19196,41 @@ Please don&apos;t submit bug reports for any of these things. Please only submit
       </modifiers>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
-  <sharedRules>
-    <rule name="Infantry Unit Type" id="d518-ea26-a708-e6a1" hidden="false"/>
-    <rule name="Walker Unit Type" id="a4d9-6b9e-822f-d40b" hidden="false"/>
-    <rule name="Vehicle Unit Type" id="3fc1-3428-792e-2703" hidden="false"/>
-    <rule name="Heavy Unit Sub-type" id="7d35-4d6f-c4fe-4aac" hidden="false"/>
-    <rule name="Sergeant Unit Sub-type" id="de7e-d90d-ffb6-c740" hidden="false"/>
-    <rule name="Command Unit Sub-type" id="7b6d-2e0d-8659-252d" hidden="false"/>
-  </sharedRules>
   <sharedProfiles>
     <profile name="New Profile" typeId="e7bb-e864-2195-b3f7" typeName="Cybertheurgic Rite" hidden="false" id="bd82-19b9-0923-5da2">
       <characteristics>
         <characteristic name="Difficulty:" typeId="86d3-2d27-fd61-d020"/>
         <characteristic name="Range:" typeId="af46-4595-7eda-1c84"/>
+      </characteristics>
+    </profile>
+    <profile name="Medic!" typeId="c14c-ecfd-ea65-58c9" typeName="Reaction" hidden="false" id="f2f4-a5e4-fc21-805b">
+      <characteristics>
+        <characteristic name="Summary" typeId="5d02-0e54-0f6a-0f0b">This Reaction allows the Reactive Player to make Recovery Tests for a Unit that is the target of a Shooting Attack if the Target Unit has a Medic.</characteristic>
+        <characteristic name="Trigger" typeId="02e4-3f90-3125-f8b4">The Reactive Player may declare a Medic! Advanced Reaction in Step 9 of any Shooting Attack if the Target Unit of the Shooting Attack includes one or more Models with the Medic (X) Special Rule.</characteristic>
+        <characteristic name="Cost" typeId="954a-972f-5c94-2ede">The Reactive Player must spend 1 point of their Reaction Allotment to declare a Medic! Reaction, this cost paid as soon as the declaration is made.</characteristic>
+        <characteristic name="Target" typeId="e102-8fdd-9cd4-c0f9">The Target Unit is always the Unit which is the target of a Shooting Attack that triggered the Reaction. Once the cost has been paid, the Reactive Player must select one eligible Unit under their control that is a target of that Shooting Attack. That Unit is the Reacting Unit.</characteristic>
+        <characteristic name="Process" typeId="57cf-1c68-a020-2529">1. Once a Medic! Advanced Reaction has been declared, the Active Player continues resolving that Shooting Attack.
+2. In Step 11 of that Shooting Attack, the Reactive Player may make one Recovery Test for each Model in the Target Unit that is allocated an Unsaved Wound - but no more than one Recovery Test may be made for any single Model. However, no Recovery Tests may be made for any Model in the Target Unit that has the Medic (X) Special Rule.</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Shieldwall!" typeId="c14c-ecfd-ea65-58c9" typeName="Reaction" hidden="false" id="e70e-0849-1ca6-81d6">
+      <characteristics>
+        <characteristic name="Summary" typeId="5d02-0e54-0f6a-0f0b">This Reaction allows the Reactive Player to gain a bonus to the Toughness Characteristic of Models in a Unit targeted by a Shooting Attack or Volley Attack if the majority of those Models have the Shield Trait.</characteristic>
+        <characteristic name="Trigger" typeId="02e4-3f90-3125-f8b4">The Reactive Player may declare a Shieldwall! Reaction in the Shooting Phase, at the start of Step 3 of the Shooting Attack sequence of any Shooting Attack made by the Active Player, or at the start of Step 4 of a Charge declared by the Active Player.</characteristic>
+        <characteristic name="Cost" typeId="954a-972f-5c94-2ede">The Reactive Player must spend 1 point of their Reaction Allotment to declare a Shieldwall! Reaction, this cost paid as soon as the declaration is made.</characteristic>
+        <characteristic name="Target" typeId="e102-8fdd-9cd4-c0f9">For a Shieldwall! Reaction, the Reacting Unit is always the Unit that was the target of the Shooting Attack or Charge that triggered the Reaction. This Unit must include a majority of Models with the ‘Shield’ Trait at the point when the Reaction is declared.</characteristic>
+        <characteristic name="Process" typeId="57cf-1c68-a020-2529">1. The Active Player continues to resolve this Shooting Attack as normal.
+2. All Models in the Unit for which this Advanced Reaction is declared have their Toughness Characteristic modified by +1 for the duration of the Phase in which this Reaction was declared</characteristic>
+      </characteristics>
+    </profile>
+    <profile name="Smokescreen" typeId="c14c-ecfd-ea65-58c9" typeName="Reaction" hidden="false" id="999b-689a-4ee7-8901">
+      <characteristics>
+        <characteristic name="Summary" typeId="5d02-0e54-0f6a-0f0b">This Reaction allows the Reactive Player to gain Shrouded Damage Mitigation Rolls for a Model with the Smokescreen Trait.</characteristic>
+        <characteristic name="Trigger" typeId="02e4-3f90-3125-f8b4">The Reactive Player may declare a Smokescreen Advanced Reaction in the Shooting Phase, at the start of Step 3 of the Shooting Attack sequence of any Shooting Attack made by the Active Player.</characteristic>
+        <characteristic name="Cost" typeId="954a-972f-5c94-2ede">The Reactive Player must spend 1 point of their Reaction Allotment to declare a Smokescreen Advanced Reaction, this cost paid as soon as the declaration is made.</characteristic>
+        <characteristic name="Target" typeId="e102-8fdd-9cd4-c0f9">For a Smokescreen Advanced Reaction, the Reacting Unit is always the Unit that was the target of the Shooting Attack that triggered the Advanced Reaction. This Unit must include a majority of Models with the Smokescreen Trait at the point where the Advanced Reaction is declared.</characteristic>
+        <characteristic name="Process" typeId="57cf-1c68-a020-2529">1. The Active Player continues to resolve this Shooting Attack as normal.
+2. All Models in the Unit for which this Reaction was declared gain a 5+ Shrouded Damage Mitigation Test against any wounds, Penetrating Hits or Glancing Hits inflicted during any Shooting Attack made in the same Phase in which this Reaction was declared.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -896,9 +896,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <modifier type="set" value="Explodes (6+)" field="name"/>
           </modifiers>
         </infoLink>
-        <infoLink name="Heavy Unit Sub-type" id="78d8-9665-f105-6fcd" hidden="false" type="rule" targetId="7d35-4d6f-c4fe-4aac"/>
         <infoLink name="Implacable Advance" id="2045-eb13-b009-9657" hidden="false" type="rule" targetId="3898-aafb-35e0-141b"/>
-        <infoLink name="Infantry Unit Type" id="910d-cea2-8a8e-38a7" hidden="false" type="rule" targetId="d518-ea26-a708-e6a1"/>
         <infoLink name="Slow and Purposeful" id="e410-2493-ad7d-6e51" hidden="false" type="rule" targetId="6a8e-e508-abc9-cb3e"/>
       </infoLinks>
       <categoryLinks>
@@ -1659,7 +1657,6 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </infoLink>
         <infoLink name="Implacable Advance" id="3b22-41a7-1b11-db34" hidden="false" type="rule" targetId="3898-aafb-35e0-141b"/>
-        <infoLink name="Infantry Unit Type" id="12a0-7dca-8a47-c4e1" hidden="false" type="rule" targetId="d518-ea26-a708-e6a1"/>
         <infoLink name="Slow and Purposeful" id="884d-c920-88e9-d201" hidden="false" type="rule" targetId="6a8e-e508-abc9-cb3e"/>
       </infoLinks>
       <selectionEntryGroups>

--- a/Thousand Sons.cat
+++ b/Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="11" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="12" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Magnus the Red" hidden="false" id="cf2e-fa27-23ce-7502">
       <selectionEntries>
@@ -748,7 +748,6 @@ Immovable Force (Telekinesis Discipline)</description>
               </modifiers>
               <comment>2</comment>
             </infoLink>
-            <infoLink name="Command Unit Sub-type" id="6f95-5e56-3d52-49fb" hidden="false" type="rule" targetId="7b6d-2e0d-8659-252d"/>
           </infoLinks>
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Prosperine Spirestave" hidden="false" id="d0ea-1c9c-779e-f0c7" sortIndex="1">


### PR DESCRIPTION
Fixes #1062

Found a load of redundant <X> Unit Type Rules with no details that weren't needed in the GST. These have since been replaced by <X> Model Type or Model Sub-Type categories.

Removed all references to them and removed the rules themselves.

<img width="1088" height="602" alt="image" src="https://github.com/user-attachments/assets/25f64676-82d5-4f5d-ac85-50945340a8e5" />
