### PR TITLE
Fully implement TS Cult Arcana

### DIFF
--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="48" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="49" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>
@@ -17536,12 +17536,17 @@ Once per Turn, if a Unit that contains Models with this Special Rule is within 1
           </conditions>
         </modifier>
         <modifier type="add" value="9254-b1e9-98b2-6101" field="category"/>
+        <modifier type="set" value="1" field="d39c-96ff-ccfa-38e5">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+          </conditions>
+        </modifier>
       </modifiers>
       <infoLinks>
         <infoLink name="Cult Arcana" id="25b1-b1f9-280a-9e72" hidden="false" type="rule" targetId="f622-94c0-3997-9ee5"/>
       </infoLinks>
       <constraints>
-        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d39c-96ff-ccfa-38e5"/>
+        <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="d39c-96ff-ccfa-38e5" automatic="true"/>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7a9d-100f-f468-bfc2"/>
       </constraints>
     </selectionEntry>

--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -313,6 +313,14 @@
                       </conditions>
                     </modifierGroup>
                   </modifierGroups>
+                  <modifiers>
+                    <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                      </conditions>
+                      <comment>TS Only - Cult Arcana</comment>
+                    </modifier>
+                  </modifiers>
                 </profile>
               </profiles>
               <entryLinks>
@@ -455,6 +463,14 @@
                       <comment>Master Sergeant</comment>
                     </modifierGroup>
                   </modifierGroups>
+                  <modifiers>
+                    <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                      </conditions>
+                      <comment>TS Only - Cult Arcana</comment>
+                    </modifier>
+                  </modifiers>
                 </profile>
               </profiles>
               <entryLinks>
@@ -644,6 +660,7 @@
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="a63f-fc3f-b619-049a" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="e20e-f623-b6c9-9989" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="951e-35bd-6e6e-e22a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -723,6 +740,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <selectionEntryGroups>
@@ -828,6 +853,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <selectionEntryGroups>
@@ -917,6 +950,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="1919-f38a-998a-e7b4" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="3db7-d5ba-a4a4-2bc3" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Centurion" hidden="false" id="3392-e93d-79bc-d648" sortIndex="4">
@@ -998,6 +1032,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="atLeast" value="1" field="selections" scope="parent" childId="b824-c0ad-804e-0026" shared="true" includeChildSelections="true"/>
                   </conditions>
                   <comment>DA Paladin</comment>
+                </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -1481,6 +1521,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             </modifier>
           </modifiers>
         </entryLink>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="a8db-2d78-1d65-eb28" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="0b5d-d2e7-1d99-e361" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -1584,6 +1625,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -1633,6 +1682,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="81e0-c9a5-79d4-99dc" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="afde-bd65-6eb5-18b8" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="6"/>
         <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="24f5-3a4a-7266-6951" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="7"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="81c7-abae-9d2f-82df" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="Master of the Legion" id="a4f6-bab7-47e9-a8b0" hidden="false" type="profile" targetId="6cd2-96be-b703-6d57"/>
@@ -1712,7 +1762,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -1940,7 +1990,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -2151,6 +2201,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="f65d-665e-8e67-224c" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="1518-62b7-e2e6-e484" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="81bb-3774-5033-549a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -2217,6 +2268,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="8d73-0084-f7e4-97d7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="5f3a-2301-3e69-23e3" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Sergeant" hidden="false" id="5809-c342-b9e6-740a" defaultAmount="1" sortIndex="1">
@@ -2244,7 +2296,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -2367,7 +2419,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -2586,6 +2638,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="d00a-e269-2ed3-8fc4" shared="true"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup type="and">
@@ -2716,6 +2774,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="670f-745d-764c-abe5" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="61bc-05a8-7d7a-1745" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="b664-2c88-4125-eee5" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -2891,6 +2950,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant - Existing Champion</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -3147,6 +3214,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <costs>
@@ -3334,6 +3409,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="6bb8-fd9b-2f17-5485" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="d1ac-e1c0-b8fb-9df3" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="50"/>
@@ -3642,6 +3718,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <costs>
@@ -3877,6 +3961,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -4014,6 +4106,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7329-57ce-10c2-4c0b" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="6a93-adec-0529-0ce9" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="25"/>
@@ -4077,6 +4170,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <costs>
@@ -4251,6 +4352,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -4368,6 +4477,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="63ca-dc78-45c8-9071" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="9b2f-b7fd-8949-8e75" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="32"/>
@@ -4419,7 +4529,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -4534,7 +4644,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -4680,6 +4790,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="36cd-be62-0f8c-19c7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="8419-f20d-d96d-db3a" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="Line (X)" id="e24e-5c1c-81dd-fdee" hidden="false" type="rule" targetId="1b5d-ceec-802a-c611">
@@ -4729,6 +4840,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="d00a-e269-2ed3-8fc4" shared="true"/>
                   </conditions>
+                </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -4797,6 +4914,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="155b-0047-db69-53d5" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="bf12-7033-7ccb-e2fc" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="May exchange anvilus autocannon battery" id="c6c1-d3eb-7bdf-0e58" hidden="false" defaultSelectionEntryId="5f77-6850-58d7-65c2" sortIndex="2">
@@ -4869,6 +4987,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="d00a-e269-2ed3-8fc4" shared="true"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup type="and">
@@ -4933,6 +5057,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="9e7d-2345-2160-3bc8" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="e4b7-b35c-a196-0803" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="8f8b-544e-d186-b4cf" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -5197,6 +5322,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="equalTo" value="1" field="selections" scope="unit" childId="9e29-3097-e7b7-8f26" shared="true"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup type="and">
@@ -5291,6 +5422,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="true" id="ef28-f458-e409-7f30" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="e966-8af9-6e75-09a8" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="7"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="70ef-f2c4-8f53-3461" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Options" id="d3ff-0c94-ec92-9fd3" hidden="false" sortIndex="2">
@@ -5678,6 +5810,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="equalTo" value="1" field="selections" scope="unit" childId="1a57-febb-4a60-14fc" shared="true"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup type="and">
@@ -5904,6 +6042,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="8dc8-c5af-5e57-91ce" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="be9d-d140-21d1-0f59" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="4"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="39f1-e31d-44f1-8f71" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Optae" hidden="false" id="1653-8dfd-2881-8cec" sortIndex="6">
@@ -5940,6 +6079,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="642d-e273-f878-edb1" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="618a-dc66-7c84-e874" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="8f1c-8a1d-e284-dd8d" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="3a39-a492-a76c-eca3" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6019,6 +6159,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="equalTo" value="1" field="selections" scope="unit" childId="7cf6-a10b-c94e-0559" shared="true"/>
                   </conditions>
                   <comment>Corvid Jump Pack</comment>
+                </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -6365,6 +6511,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="atLeast" value="1" field="selections" scope="unit" childId="3139-d592-6b65-78fe" shared="true"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup type="and">
@@ -6594,6 +6746,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             </entryLink>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="31bb-917e-e2c9-af12" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Damocles Command Rhino" hidden="false" id="f214-aeb9-0dd6-9071" sortIndex="7">
@@ -6745,6 +6898,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="d2ac-2e5a-9d09-eafa" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="db94-a4fe-3a9e-1e15" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="3"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="e95b-325c-050a-de79" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Librarian" hidden="false" id="c0e4-eabd-4f0a-23ca">
@@ -6802,6 +6956,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -6928,6 +7090,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="9d42-3a8a-a947-09bd" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="8ef7-7e18-02bc-b5fa" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="2"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="7511-02d4-7943-9e5f" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="6a0a-f0fe-c889-8a8a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6994,6 +7157,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -7087,6 +7258,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -7141,6 +7320,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="dc4d-d2e6-f755-12da" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="8efe-861a-d1fd-23ca" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="3a15-3f23-412b-c620" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Esoterist" hidden="false" id="868f-f32d-d5ef-8021" sortIndex="11">
@@ -7205,6 +7385,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -7256,6 +7444,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="f5f5-76c2-907d-2dd0" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="cd92-09af-5605-9c32" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="3c25-2ec6-891d-cd83" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Master of Signals" hidden="false" id="0c1d-e55e-1d4e-ab94" sortIndex="12">
@@ -7290,6 +7479,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="c336-56cd-9107-7201" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="c204-eaec-8d5f-7e86" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="23d9-ac24-691f-e90e" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Master of Signals" hidden="false" id="f985-ac79-b28b-f341">
@@ -7351,6 +7541,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -7442,6 +7640,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -7500,6 +7706,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4ba8-283c-d509-dd3c-max"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="e997-faba-6cfd-316c" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="f17a-8cab-ca53-bba3" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -7571,6 +7778,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="equalTo" value="1" field="selections" scope="unit" childId="7cf6-a10b-c94e-0559" shared="true"/>
                   </conditions>
                   <comment>Corvid Jump Pack</comment>
+                </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -7651,6 +7864,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7684-62ef-251f-fc12" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9de9-5f17-c2e9-d10e" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="6b9e-c833-6b43-7b0b" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="b01e-114a-47d0-e7e0" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -7750,6 +7964,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -7850,6 +8072,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="3cf7-be3a-ac2e-57a7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="a132-7070-7e03-46c1" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="6c18-b47c-2535-419f" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="fce6-d23c-c7dd-862f" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -7918,6 +8141,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -8043,6 +8274,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="4423-103e-ebe5-95f7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="67b0-b445-8457-b5ec" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="7"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="2c91-99fa-215f-4835" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="363d-cd4e-6c14-9ef1" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -8120,6 +8352,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -8166,6 +8406,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="e852-3890-82fd-05a0" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="eb74-80e7-7818-bc7d" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="9283-057d-c06f-8290" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Options" id="265f-5c58-0294-dfa9" hidden="false" sortIndex="1">
@@ -8239,6 +8480,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant - Existing Champion</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -8496,6 +8745,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <costs>
@@ -8684,6 +8941,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="3aee-7cf9-9498-f1fd" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="0646-87a8-8389-26ee" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <costs>
         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="60"/>
@@ -8703,6 +8961,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7138-7174-e84a-ffd4" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="cda0-028a-9a51-26ad" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Veteran Champion" hidden="false" id="3dc3-9ea3-a9de-6f25" sortIndex="1">
@@ -8759,6 +9018,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant - Existing Champion</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -9015,6 +9282,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -9256,6 +9531,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7c9c-5c2f-a7d5-5565" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="0372-e989-f17c-b56b" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Tartaros Chosen" hidden="false" id="a224-6817-4f91-8ecb" sortIndex="2">
@@ -9301,6 +9577,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -9439,6 +9723,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant - Existing Champion</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -9558,6 +9850,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="444e-7ecd-d81b-1705" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="a616-9249-b4c5-b587" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Cataphractii Terminator" hidden="false" id="f106-8e40-a38f-427c" sortIndex="2">
@@ -9603,6 +9896,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -9777,6 +10078,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -9907,6 +10216,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="9397-a285-59a4-54b6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="9f21-92ca-470f-a8a4" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Seeker" hidden="false" id="f9c6-e107-4e90-5504" sortIndex="2">
@@ -10249,6 +10559,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="82f8-86b9-b0c6-1fbb" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="d0f7-2a18-b4e1-17de" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Tartaros Terminator" hidden="false" id="66c8-c209-2f95-c4e8" sortIndex="2">
@@ -10294,6 +10605,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -10454,6 +10773,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -10612,6 +10939,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <selectionEntryGroups>
@@ -10757,6 +11092,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant - Existing Champion</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <selectionEntryGroups>
@@ -10849,6 +11192,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="5318-9db0-630a-9353" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="7a6a-df25-5497-a654" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <categoryLinks>
         <categoryLink targetId="647c-faca-3c98-c203" id="bd89-199d-0722-bd5c" primary="false" name="Free Power Weapon"/>
@@ -10893,6 +11237,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="6f10-268e-a29d-3d35" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="a0c0-a845-a893-c737" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Legionary" hidden="false" id="9de3-15fa-986b-500a" sortIndex="2">
@@ -10920,7 +11265,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -11103,7 +11448,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -11272,7 +11617,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -11385,7 +11730,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -11468,6 +11813,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="c405-8326-3187-4028" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="a6f4-cbe6-ef54-dfba" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="9eea-baa3-681d-b174" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -11588,7 +11934,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -11693,7 +12039,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -11776,6 +12122,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="1269-9bdd-92ac-93fc" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="d2a9-c6e0-0a7c-d8d1" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Legion Heavy Weapons List" id="f3e8-47d6-ac92-2b66" hidden="false" collapsible="true" flatten="false" defaultSelectionEntryId="cf76-c4c7-8a9a-0beb" sortIndex="4">
@@ -11921,6 +12268,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -11954,6 +12309,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="b5aa-c79b-d747-f443" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="9ab1-4ec7-b0c7-4c08" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Legiones Astartes]" id="9b70-4c5c-0bb2-aa66" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
@@ -12082,6 +12438,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -12141,6 +12505,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="0ccc-b717-eb01-806f" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="1b2d-a235-34bb-7ebb" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="5700-d124-40aa-c610" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -12249,6 +12614,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                     <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="d00a-e269-2ed3-8fc4" shared="true"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
               </modifiers>
               <modifierGroups>
                 <modifierGroup type="and">
@@ -12309,6 +12680,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="ef1a-edcb-8e80-ffbb" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="9eb1-f013-d0e4-2a1c" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="97d8-faab-3b68-5553" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -13151,6 +13523,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
         </selectionEntry>
@@ -13263,6 +13643,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -13292,6 +13680,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="63dc-8c1b-468d-2569" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="a621-fd36-2b3f-4a57" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="77b0-8e50-7e5b-bf4a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -13367,7 +13756,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -13479,7 +13868,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
                   </conditions>
-                  <comment>1kSons Rite</comment>
+                  <comment>TS Only - Cult Arcana</comment>
                 </modifier>
               </modifiers>
               <modifierGroups>
@@ -13570,6 +13959,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="d00b-181e-0c96-d727" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="6e13-9bfd-7bda-419d" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="130c-24bd-a055-4001" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -13970,6 +14360,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </constraints>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="38f7-9218-224b-9d6a" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="4e80-72f1-4c4c-404b" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Scimitar Sergeant" hidden="false" id="9011-92da-37e3-f605" sortIndex="1">
@@ -14022,6 +14413,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   <comment>Master Sergeant</comment>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -14118,6 +14517,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -14530,6 +14937,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -14626,6 +15041,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="61b4-4f2d-cc27-d029" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="34b3-ddc5-143a-39a4" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Predator" hidden="false" id="b0ba-83cb-f3bf-bf2e" sortIndex="64">
@@ -14784,6 +15200,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="e821-f090-5e6d-2496" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="fbc3-98dc-0594-199b" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Land Speeder" hidden="false" id="1f3c-e351-b888-61ef" sortIndex="1">
@@ -14914,6 +15331,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <categoryLinks>
@@ -16516,6 +16941,14 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -16571,6 +17004,7 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="db4e-4a59-0f17-5abe-max"/>
           </constraints>
         </entryLink>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="39f5-b577-6ec6-dfde" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="e4cd-e660-606b-9c70" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -16685,6 +17119,14 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
           <constraints>
@@ -16745,6 +17187,7 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="5c10-a253-29c4-7ce6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9e96-13b7-4367-47c7" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="8fad-0ddd-0198-1129" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup name="Options" id="02af-aba0-5bd7-6bd2" hidden="false" sortIndex="1">
@@ -16928,6 +17371,14 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
                   </conditions>
                 </modifierGroup>
               </modifierGroups>
+              <modifiers>
+                <modifier type="increment" value="1" field="f714-1726-37d3-44df">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+                  </conditions>
+                  <comment>TS Only - Cult Arcana</comment>
+                </modifier>
+              </modifiers>
             </profile>
           </profiles>
         </selectionEntry>
@@ -16964,6 +17415,7 @@ Once per Turn, if a Unit that contains Models with this Special Rule is within 1
             <entryLink import="true" name="Prime Benefits" hidden="false" id="5c55-21bb-3e7f-8fe1" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
+        <entryLink import="true" name="Cult Arcana" hidden="false" id="0718-965a-7cc4-66d8" type="selectionEntry" targetId="0762-0377-062c-4eb1"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Hyperios Missile Tank" hidden="false" id="5999-0699-9293-04b8" sortIndex="80">
@@ -17075,6 +17527,23 @@ Once per Turn, if a Unit that contains Models with this Special Rule is within 1
           </entryLinks>
         </entryLink>
       </entryLinks>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Cult Arcana" hidden="true" id="0762-0377-062c-4eb1">
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="add" value="9254-b1e9-98b2-6101" field="category"/>
+      </modifiers>
+      <infoLinks>
+        <infoLink name="Cult Arcana" id="25b1-b1f9-280a-9e72" hidden="false" type="rule" targetId="f622-94c0-3997-9ee5"/>
+      </infoLinks>
+      <constraints>
+        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d39c-96ff-ccfa-38e5"/>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7a9d-100f-f468-bfc2"/>
+      </constraints>
     </selectionEntry>
   </sharedSelectionEntries>
   <entryLinks>

--- a/Special Rules.cat
+++ b/Special Rules.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="106b-693b-99f2-00c3" name="Special Rules" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="14" battleScribeVersion="2.03" type="catalogue" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="106b-693b-99f2-00c3" name="Special Rules" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="15" battleScribeVersion="2.03" type="catalogue" authorName="The4D6" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedRules>
     <rule name="Interdiction Cadres" id="a752-1dc3-403e-9336" hidden="false">
       <description>All Models in a Unit selected to fill a Prime Force Organization with this Prime Advantage gain the Concealed Positions and Expendable(1) Special Rules.</description>
@@ -594,6 +594,9 @@ At the End of the Charge Sub-Phase, if a Unit that includes any Models with this
 
 • The Perfect Guard - If this effect is selected, until the end of this Phase, the Weapon Skill Characteristic of each Model in this Unit with this Special Rule is considered to be one point higher than normal when determining the score an opposing Model needs to Hit this Model in the Strike Step of the Challenge Sub-Phase or the Make Hit Tests Step of the Resolving an Initiative Step Step (this does not modify the Weapon Skill Characteristics of each Model in this Unit for the purposes of Hit Tests made for their own attacks).</description>
       <comment>Emperor&apos;s Children</comment>
+    </rule>
+    <rule name="Cult Arcana" id="f622-94c0-3997-9ee5" hidden="false" publicationId="e54c-7040-0f35-d85d">
+      <description>Models with this special rule gain a bonus of +1 Base Willpower Characteristic and gain the Psyker Trait</description>
     </rule>
   </sharedRules>
   <sharedSelectionEntries>

--- a/Thousand Sons.cat
+++ b/Thousand Sons.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="13" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="2496-21e2-1870-e9b8" name="                        XV - Thousand Sons" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="14" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="Arkangelmark5" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Magnus the Red" hidden="false" id="cf2e-fa27-23ce-7502">
       <selectionEntries>
@@ -2069,16 +2069,6 @@ the Psychic Power was from a Prosperine Arcana to a Model in this Unit instead. 
     <categoryEntry name="Khenetai" id="6101-2133-e9a7-0ea9" hidden="false"/>
   </categoryEntries>
   <sharedRules>
-    <rule name="Cult Arcana" id="f622-94c0-3997-9ee5" hidden="true" publicationId="e54c-7040-0f35-d85d">
-      <description>Models with this special rule gain a bonus of +1 Base Willpower Characteristic and gain the Psyker Trait</description>
-      <modifiers>
-        <modifier type="set" value="false" field="hidden">
-          <conditions>
-            <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="2496-21e2-1870-e9b8" shared="true"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-    </rule>
     <rule name="Sire of the Thousand Sons" id="eeb4-4067-9bb3-abc2" hidden="false" publicationId="e54c-7040-0f35-d85d">
       <description>Until the end of the first Battle Turn of the Battle, whenever the Controlling Player of a Model with this Special Rule makes a Manifestation Check for a Unit that only includes Models with the Thousand Sons Trait, they may roll three Dice and select any two to determine the result.</description>
     </rule>


### PR DESCRIPTION
Fixes #1092

There was a very partial implementation across LA - now every non-vehicle unit has the rule, the Psyker trait and the +1 WP dependent on being TS

<img width="823" height="881" alt="image" src="https://github.com/user-attachments/assets/b70fa159-f797-4880-8be6-57239552f013" />
