### PR TITLE
Fix LA Command Units to have the right structure

### DIFF
--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="49" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="50" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>
@@ -1041,182 +1041,36 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="bd0c-2020-4e97-bf5f" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="7d33-919e-4084-a326" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="d6e1-87c8-3d1f-45a4" hidden="false" sortIndex="6">
-          <entryLinks>
-            <entryLink import="true" name="Pair of lightning claws" hidden="false" id="cd1e-986e-8224-8902" type="selectionEntry" targetId="6754-24dd-5be0-26ff" sortIndex="1">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c632-d3e7-c645-4df0" includeChildSelections="false"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="true" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </entryLink>
-            <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="5652-55c9-c007-9c0f" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256" sortIndex="2">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <comment>RG+Cmd Only</comment>
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dc8f-be42-0ebd-76c3"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="1e3d-2ca5-1ade-76fe" includeChildSelections="false"/>
-          </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolter for:" id="ada7-e558-58a6-8710" hidden="false">
+            <selectionEntryGroup name="Jump Pack" id="6f78-21cb-8853-b980" hidden="false" flatten="true" sortIndex="1">
               <entryLinks>
-                <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="4f6f-c82a-5990-5171" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" flatten="false">
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="0f2b-a3a4-b2a8-f4d1" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e" sortIndex="1" defaultAmount="1">
-                      <modifiers>
-                        <modifier type="set" value="Bolter (default)" field="name"/>
-                      </modifiers>
-                    </entryLink>
-                  </entryLinks>
-                  <comment>Exchange bolter for</comment>
-                </entryLink>
-                <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="617b-c564-4ced-b61b" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08" flatten="false">
-                  <comment>Exchange bolter for</comment>
-                </entryLink>
-                <entryLink import="true" name="Volkite charger" hidden="false" id="86d1-a8d5-c18c-a877" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="7">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Astartes shotgun" hidden="false" id="17fc-1c47-21a2-c5cb" type="selectionEntry" targetId="6068-d203-27e6-318a" sortIndex="6">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="false" id="81a9-ce8f-3922-05e2" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
-                  </costs>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e8cb-f6c5-7f6d-ca2c"/>
-                  </constraints>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="d800-e05d-1dc5-e44a" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
-                  </costs>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ef3e-257d-1090-0cf2"/>
-                  </constraints>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter" hidden="true" id="608b-ae87-2157-beed" type="selectionEntry" targetId="69de-4883-efd2-b876" sortIndex="1">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-                  </costs>
-                  <modifiers>
-                    <modifier type="set" value="false" field="hidden">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition type="instanceOf" value="1" field="selections" scope="force" childId="ac06-fcec-b634-5bd9" shared="true" includeChildSelections="true"/>
-                          </conditions>
-                          <comment>SH</comment>
-                          <conditionGroups>
-                            <conditionGroup type="or">
-                              <conditions>
-                                <condition type="atLeast" value="1" field="selections" scope="parent" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
-                                <condition type="atLeast" value="1" field="selections" scope="parent" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
-                              </conditions>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </conditionGroup>
-                      </conditionGroups>
-                      <comment>SH+Cmd/Champ Only</comment>
-                    </modifier>
-                  </modifiers>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f466-92e3-e175-8d54"/>
-                  </constraints>
-                </entryLink>
-                <entryLink import="true" name="Terranic greatsword" hidden="true" id="5b84-ba7c-af89-bd3e" type="selectionEntry" targetId="f1aa-3d18-caac-a960">
-                  <comment>DA Paladin</comment>
-                  <constraints>
-                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="86ac-e916-5776-130c" includeChildSelections="false"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2873-32ec-aaa5-a5a2" includeChildSelections="false"/>
-                  </constraints>
+                <entryLink import="true" name="Corvid Pattern Jump Pack" hidden="true" id="7cf6-a10b-c94e-0559" type="selectionEntry" targetId="3f94-3ed7-02ee-0c1b" sortIndex="2">
                   <modifiers>
                     <modifier type="set" value="false" field="hidden">
                       <conditions>
-                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="b824-c0ad-804e-0026" shared="true" includeChildSelections="true"/>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
                       </conditions>
                     </modifier>
-                    <modifier type="set" value="1" field="86ac-e916-5776-130c">
-                      <conditions>
-                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="b824-c0ad-804e-0026" shared="true" includeChildSelections="true"/>
-                      </conditions>
-                    </modifier>
+                    <modifier type="add" value="294e-d64c-39dc-f687" field="category"/>
                   </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
+                  </costs>
                 </entryLink>
               </entryLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="4b81-0ea1-5c3e-737f" includeChildSelections="false"/>
-              </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="3440-77e6-70a8-6c26" sortIndex="2">
+                <selectionEntry type="upgrade" import="true" name="Jump Pack" hidden="false" id="ebe2-88e3-d933-65a4" sortIndex="1">
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
                     <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
                     <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
                   </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="921b-e993-55be-eb8f" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6057-1ebd-9f60-70b3" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="44f4-3fff-d07b-a163" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Bayonet" hidden="false" id="d986-e6dd-b589-d0d8" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9e04-e0a5-9786-0f1c" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3149-7d96-dd6e-e7af" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="f89f-a243-e6da-e7d2" sortIndex="4">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                    <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                    <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-                  </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="c609-7169-858f-5a20" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3c00-8b1b-1b47-62b8" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7d66-6a52-ebb2-a2b1" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Chain bayonet" hidden="false" id="0bc0-4fff-e10f-8365" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="676a-a475-d567-af80" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cacb-12c3-b141-1faa" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5f30-8075-ca27-30a3" includeChildSelections="false"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="add" value="294e-d64c-39dc-f687" field="category"/>
+                  </modifiers>
                 </selectionEntry>
               </selectionEntries>
               <modifiers>
@@ -1227,72 +1081,310 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 </modifier>
               </modifiers>
             </selectionEntryGroup>
-            <selectionEntryGroup name="May exchange bolt pistol for:" id="603b-4824-ba0a-2aea" hidden="false" collapsible="true">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="c340-89d3-a7c2-9be5" sortIndex="2">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                    <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                    <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-                  </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="2984-ec1a-3215-2cb4" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2c14-2b24-0ff5-1382" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3dff-f769-7502-dfc3" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Chain bayonet" hidden="false" id="03be-4f6e-fd59-1488" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7f4c-8b8d-67e7-7399" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ea49-a847-6055-7562" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="c652-2726-34c5-8ff2" sortIndex="1">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
-                    <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                    <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-                  </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="9a07-cd4f-ac59-52af" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d36-d5c2-019f-e6c7" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d4e1-89c7-3817-9854" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Bayonet" hidden="false" id="d9b4-2f82-59d6-a2bf" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ad1d-342c-a7ed-e39b" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee5e-ffe1-a657-eb6c" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntry>
-              </selectionEntries>
+            <selectionEntryGroup name="Options" id="d6e1-87c8-3d1f-45a4" hidden="false" sortIndex="2">
               <entryLinks>
-                <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="88bc-6163-0b4b-c8af" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="3" flatten="false">
+                <entryLink import="true" name="Pair of lightning claws" hidden="false" id="cd1e-986e-8224-8902" type="selectionEntry" targetId="6754-24dd-5be0-26ff" sortIndex="1">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                  </costs>
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="4741-5b1b-6614-1152" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c632-d3e7-c645-4df0" includeChildSelections="false"/>
                   </constraints>
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="5652-55c9-c007-9c0f" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256" sortIndex="2">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <comment>RG+Cmd Only</comment>
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dc8f-be42-0ebd-76c3"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="1e3d-2ca5-1ade-76fe" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolter for:" id="ada7-e558-58a6-8710" hidden="false">
                   <entryLinks>
-                    <entryLink import="true" name="Bolt pistol" hidden="false" id="91e2-95fd-848a-1373" type="selectionEntry" targetId="2942-f783-d627-33c5" defaultAmount="1">
+                    <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="4f6f-c82a-5990-5171" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" flatten="false">
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="0f2b-a3a4-b2a8-f4d1" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e" sortIndex="1" defaultAmount="1">
+                          <modifiers>
+                            <modifier type="set" value="Bolter (default)" field="name"/>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                      <comment>Exchange bolter for</comment>
+                    </entryLink>
+                    <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="617b-c564-4ced-b61b" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08" flatten="false">
+                      <comment>Exchange bolter for</comment>
+                    </entryLink>
+                    <entryLink import="true" name="Volkite charger" hidden="false" id="86d1-a8d5-c18c-a877" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="7">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Astartes shotgun" hidden="false" id="17fc-1c47-21a2-c5cb" type="selectionEntry" targetId="6068-d203-27e6-318a" sortIndex="6">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="false" id="81a9-ce8f-3922-05e2" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
+                      </costs>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e8cb-f6c5-7f6d-ca2c"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="d800-e05d-1dc5-e44a" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
+                      </costs>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ef3e-257d-1090-0cf2"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter" hidden="true" id="608b-ae87-2157-beed" type="selectionEntry" targetId="69de-4883-efd2-b876" sortIndex="1">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                      </costs>
                       <modifiers>
-                        <modifier type="set" value="Bolt pistol (default)" field="name"/>
-                        <modifier type="set" value="0" field="defaultAmount">
+                        <modifier type="set" value="false" field="hidden">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition type="instanceOf" value="1" field="selections" scope="force" childId="ac06-fcec-b634-5bd9" shared="true" includeChildSelections="true"/>
+                              </conditions>
+                              <comment>SH</comment>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
+                                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                          <comment>SH+Cmd/Champ Only</comment>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f466-92e3-e175-8d54"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink import="true" name="Terranic greatsword" hidden="true" id="5b84-ba7c-af89-bd3e" type="selectionEntry" targetId="f1aa-3d18-caac-a960">
+                      <comment>DA Paladin</comment>
+                      <constraints>
+                        <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="86ac-e916-5776-130c" includeChildSelections="false"/>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2873-32ec-aaa5-a5a2" includeChildSelections="false"/>
+                      </constraints>
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
                           <conditions>
-                            <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                            <condition type="atLeast" value="1" field="selections" scope="parent" childId="b824-c0ad-804e-0026" shared="true" includeChildSelections="true"/>
+                          </conditions>
+                        </modifier>
+                        <modifier type="set" value="1" field="86ac-e916-5776-130c">
+                          <conditions>
+                            <condition type="atLeast" value="1" field="selections" scope="parent" childId="b824-c0ad-804e-0026" shared="true" includeChildSelections="true"/>
                           </conditions>
                         </modifier>
                       </modifiers>
                     </entryLink>
                   </entryLinks>
-                </entryLink>
-              </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="4b81-0ea1-5c3e-737f" includeChildSelections="false"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="3440-77e6-70a8-6c26" sortIndex="2">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
+                        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                      </costs>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="921b-e993-55be-eb8f" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6057-1ebd-9f60-70b3" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="44f4-3fff-d07b-a163" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Bayonet" hidden="false" id="d986-e6dd-b589-d0d8" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9e04-e0a5-9786-0f1c" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3149-7d96-dd6e-e7af" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="f89f-a243-e6da-e7d2" sortIndex="4">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                      </costs>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="c609-7169-858f-5a20" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3c00-8b1b-1b47-62b8" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7d66-6a52-ebb2-a2b1" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Chain bayonet" hidden="false" id="0bc0-4fff-e10f-8365" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="676a-a475-d567-af80" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cacb-12c3-b141-1faa" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May exchange bolt pistol for:" id="603b-4824-ba0a-2aea" hidden="false" collapsible="true">
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="c340-89d3-a7c2-9be5" sortIndex="2">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                      </costs>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="2984-ec1a-3215-2cb4" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2c14-2b24-0ff5-1382" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3dff-f769-7502-dfc3" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Chain bayonet" hidden="false" id="03be-4f6e-fd59-1488" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7f4c-8b8d-67e7-7399" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ea49-a847-6055-7562" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="c652-2726-34c5-8ff2" sortIndex="1">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
+                        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                      </costs>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="9a07-cd4f-ac59-52af" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d36-d5c2-019f-e6c7" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d4e1-89c7-3817-9854" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Bayonet" hidden="false" id="d9b4-2f82-59d6-a2bf" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ad1d-342c-a7ed-e39b" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee5e-ffe1-a657-eb6c" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="88bc-6163-0b4b-c8af" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="3" flatten="false">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="4741-5b1b-6614-1152" includeChildSelections="false"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolt pistol" hidden="false" id="91e2-95fd-848a-1373" type="selectionEntry" targetId="2942-f783-d627-33c5" defaultAmount="1">
+                          <modifiers>
+                            <modifier type="set" value="Bolt pistol (default)" field="name"/>
+                            <modifier type="set" value="0" field="defaultAmount">
+                              <conditions>
+                                <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                              </conditions>
+                            </modifier>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="681e-edc8-6e07-e480" includeChildSelections="false"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Heavy Weapons" id="c9f5-b1a3-b8c4-cee9" hidden="true">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" value="1" field="bd18-d2ce-8654-aacb">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <comment>Imperial Fist Castellan options</comment>
+                  <entryLinks>
+                    <entryLink import="true" name="Heavy bolter" hidden="false" id="dd41-6429-c170-3b2f" type="selectionEntry" targetId="bc40-b14a-978e-0232"/>
+                    <entryLink import="true" name="Autocannon" hidden="false" id="dd0f-2e0d-6c37-a242" type="selectionEntry" targetId="da6e-3b8a-ea61-1e93"/>
+                    <entryLink import="true" name="Iliastus Assault Cannon" hidden="false" id="e9bf-8128-9423-b67c" type="selectionEntry" targetId="f38b-8af1-17b8-30fe"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6a63-6b06-fb5a-9e1b" automatic="true"/>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="bd18-d2ce-8654-aacb"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <modifiers>
+                <modifier type="set" value="1" field="1e3d-2ca5-1ade-76fe">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="ab57-e7ca-3fc7-b256" shared="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="6754-24dd-5be0-26ff" shared="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="c6c3-1d43-667d-9358" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="681e-edc8-6e07-e480" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="febc-3bad-e6e0-b7f0" includeChildSelections="false"/>
               </constraints>
               <modifiers>
                 <modifier type="set" value="true" field="hidden">
@@ -1301,176 +1393,86 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                   </conditions>
                 </modifier>
               </modifiers>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="Heavy Weapons" id="c9f5-b1a3-b8c4-cee9" hidden="true">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="1" field="bd18-d2ce-8654-aacb">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <comment>Imperial Fist Castellan options</comment>
-              <entryLinks>
-                <entryLink import="true" name="Heavy bolter" hidden="false" id="dd41-6429-c170-3b2f" type="selectionEntry" targetId="bc40-b14a-978e-0232"/>
-                <entryLink import="true" name="Autocannon" hidden="false" id="dd0f-2e0d-6c37-a242" type="selectionEntry" targetId="da6e-3b8a-ea61-1e93"/>
-                <entryLink import="true" name="Iliastus Assault Cannon" hidden="false" id="e9bf-8128-9423-b67c" type="selectionEntry" targetId="f38b-8af1-17b8-30fe"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6a63-6b06-fb5a-9e1b" automatic="true"/>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="bd18-d2ce-8654-aacb"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <modifiers>
-            <modifier type="set" value="1" field="1e3d-2ca5-1ade-76fe">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="parent" childId="ab57-e7ca-3fc7-b256" shared="true"/>
-                    <condition type="equalTo" value="1" field="selections" scope="parent" childId="6754-24dd-5be0-26ff" shared="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Jump Pack" id="6f78-21cb-8853-b980" hidden="false" flatten="true" sortIndex="1">
-          <entryLinks>
-            <entryLink import="true" name="Corvid Pattern Jump Pack" hidden="true" id="7cf6-a10b-c94e-0559" type="selectionEntry" targetId="3f94-3ed7-02ee-0c1b" sortIndex="2">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="add" value="294e-d64c-39dc-f687" field="category"/>
-              </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
-              </costs>
             </entryLink>
-          </entryLinks>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Jump Pack" hidden="false" id="ebe2-88e3-d933-65a4" sortIndex="1">
+            <entryLink import="true" name="Cyber-familiar" hidden="false" id="b845-4950-8a4d-9326" type="selectionEntry" targetId="a545-36ec-d50e-2ae4" sortIndex="6">
               <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-                <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
               </costs>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5f30-8075-ca27-30a3" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8ac8-599c-ecdc-a772" includeChildSelections="false"/>
               </constraints>
               <modifiers>
-                <modifier type="add" value="294e-d64c-39dc-f687" field="category"/>
+                <modifier type="set" value="true" field="hidden">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="ebe2-88e3-d933-65a4" shared="true"/>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
-            </selectionEntry>
-          </selectionEntries>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+            </entryLink>
+            <entryLink import="true" name="Vexilla" hidden="false" id="aa08-a8e0-57a1-25c7" type="selectionEntry" targetId="dfcd-0669-ad43-28aa" sortIndex="7">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+              </costs>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="ebe2-88e3-d933-65a4" shared="true"/>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="98e1-45cb-9d92-ceea" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="c143-d02b-b70a-445a" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="8"/>
+            <entryLink import="true" name="Breacher Charges" hidden="false" id="06b6-7483-0edb-9d1a" type="selectionEntry" targetId="01bd-4377-904c-6625" sortIndex="9">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6819-7e13-adc5-abae"/>
+              </constraints>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditions>
+                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="a24f-980a-79e3-d168" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7853-36ab-58f5-cb6c" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6179-d1d0-908a-5cdb" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="6907-5c89-523b-085b" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="02ae-638d-4f67-e768" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4087-60c3-fc0d-b2a6" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="e4f9-dc27-a48f-ede6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="10"/>
+          </entryLinks>
+        </selectionEntry>
+      </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Vexilla" hidden="false" id="aa08-a8e0-57a1-25c7" type="selectionEntry" targetId="dfcd-0669-ad43-28aa" sortIndex="5">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="ebe2-88e3-d933-65a4" shared="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="98e1-45cb-9d92-ceea" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Cyber-familiar" hidden="false" id="b845-4950-8a4d-9326" type="selectionEntry" targetId="a545-36ec-d50e-2ae4" sortIndex="4">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8ac8-599c-ecdc-a772" includeChildSelections="false"/>
-          </constraints>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="ebe2-88e3-d933-65a4" shared="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="c6c3-1d43-667d-9358" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="3">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="febc-3bad-e6e0-b7f0" includeChildSelections="false"/>
-          </constraints>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="a24f-980a-79e3-d168" type="selectionEntry" targetId="60e4-ca33-2e68-9afc">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7853-36ab-58f5-cb6c" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6179-d1d0-908a-5cdb" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="6907-5c89-523b-085b" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="02ae-638d-4f67-e768" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4087-60c3-fc0d-b2a6" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="9761-cb4c-ae08-7e1d" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="90f8-0e89-acff-a748" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
-        </entryLink>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="c143-d02b-b70a-445a" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="7"/>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="e4f9-dc27-a48f-ede6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Breacher Charges" hidden="false" id="06b6-7483-0edb-9d1a" type="selectionEntry" targetId="01bd-4377-904c-6625" sortIndex="8">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6819-7e13-adc5-abae"/>
-          </constraints>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditions>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="da17-ab73-7d33-c76f" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
         </entryLink>
         <entryLink import="true" name="Orders of the Hekatonystika" hidden="true" id="110f-698b-dc8c-ca58" type="selectionEntryGroup" targetId="9035-6bbe-3431-876d">
           <modifiers>
@@ -1535,7 +1537,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Praetor in Saturnine Terminator Armour" hidden="false" id="2a5a-8ab8-be4d-6fa7" sortIndex="3">
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Saturnine Praetor" hidden="false" id="0b24-87fb-26e8-13d2">
+        <selectionEntry type="model" import="true" name="Saturnine Praetor" hidden="false" id="0b24-87fb-26e8-13d2" sortIndex="1">
           <profiles>
             <profile name="Saturnine Praetor" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="bb05-5cc6-b512-1692">
               <characteristics>
@@ -1595,6 +1597,60 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="9871-cb62-5283-2216" id="830e-9aa5-4145-b498" primary="false" name="Command Model Sub-type"/>
             <categoryLink targetId="1e7d-9066-28d2-97a0" id="739f-02a5-497a-b2da" primary="false" name="Heavy Model Sub-Type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Melee Weapons:" id="3204-79db-bbc4-2000" hidden="false" sortIndex="1">
+              <entryLinks>
+                <entryLink import="true" name="Saturnine disruption fist" hidden="false" id="7ba6-70ba-7af4-493a" type="selectionEntry" targetId="487c-7be9-48db-e02a" sortIndex="2" defaultAmount="1">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="32f9-ab76-e8b1-1907" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Saturnine war axe" hidden="false" id="348d-05b8-1b3b-a99a" type="selectionEntry" targetId="2c38-5c75-ae96-1391" sortIndex="1" defaultAmount="1">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="035a-eb81-74b3-6c1f" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Saturnine concussion hammer" hidden="false" id="1d04-8d3d-cfff-17c9" type="selectionEntry" targetId="5245-80e4-d107-3847" sortIndex="3">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="534a-f97b-36ec-2c1b" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <constraints>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="69fb-fae0-5350-940b" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="a322-51ad-f1d9-c986" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Thermal Diffraction Field" hidden="false" id="3a50-2adf-1972-4538" type="selectionEntry" targetId="ae43-8418-ecb1-ef6e" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ff5d-fe4e-c653-e830" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="12ec-8a8f-47ea-224e" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Plasma blaster" hidden="false" id="5703-310b-02cf-6222" type="selectionEntry" targetId="3787-3dca-b6c9-f9e3" sortIndex="3">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4cd6-0593-ca82-07bf" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Saturnine teleportation transponder" hidden="false" id="3333-b8dd-3c2d-ec82" type="selectionEntry" targetId="b347-5137-3d53-53ab" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="60"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1803-1fa2-7fe4-7cce" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="81e0-c9a5-79d4-99dc" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="afde-bd65-6eb5-18b8" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="6"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <costs>
@@ -1603,36 +1659,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Prime Unit" hidden="false" id="943f-e958-461a-bb23" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
+        <entryLink import="true" name="Prime Unit" hidden="false" id="943f-e958-461a-bb23" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2" sortIndex="3">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="7ed7-0182-49eb-959c" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Thermal Diffraction Field" hidden="false" id="3a50-2adf-1972-4538" type="selectionEntry" targetId="ae43-8418-ecb1-ef6e" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ff5d-fe4e-c653-e830" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="12ec-8a8f-47ea-224e" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Plasma blaster" hidden="false" id="5703-310b-02cf-6222" type="selectionEntry" targetId="3787-3dca-b6c9-f9e3" sortIndex="3">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4cd6-0593-ca82-07bf" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Saturnine teleportation transponder" hidden="false" id="3333-b8dd-3c2d-ec82" type="selectionEntry" targetId="b347-5137-3d53-53ab" sortIndex="4">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="60"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1803-1fa2-7fe4-7cce" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="81e0-c9a5-79d4-99dc" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="afde-bd65-6eb5-18b8" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="6"/>
-        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="24f5-3a4a-7266-6951" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="7"/>
+        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="24f5-3a4a-7266-6951" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="2"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="Master of the Legion" id="a4f6-bab7-47e9-a8b0" hidden="false" type="profile" targetId="6cd2-96be-b703-6d57"/>
@@ -1646,34 +1678,6 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <infoLink name="Implacable Advance" id="3b22-41a7-1b11-db34" hidden="false" type="rule" targetId="3898-aafb-35e0-141b"/>
         <infoLink name="Slow and Purposeful" id="884d-c920-88e9-d201" hidden="false" type="rule" targetId="6a8e-e508-abc9-cb3e"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Melee Weapons:" id="3204-79db-bbc4-2000" hidden="false" sortIndex="1">
-          <entryLinks>
-            <entryLink import="true" name="Saturnine disruption fist" hidden="false" id="7ba6-70ba-7af4-493a" type="selectionEntry" targetId="487c-7be9-48db-e02a" sortIndex="2" defaultAmount="1">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="32f9-ab76-e8b1-1907" includeChildSelections="false"/>
-              </constraints>
-            </entryLink>
-            <entryLink import="true" name="Saturnine war axe" hidden="false" id="348d-05b8-1b3b-a99a" type="selectionEntry" targetId="2c38-5c75-ae96-1391" sortIndex="1" defaultAmount="1">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="035a-eb81-74b3-6c1f" includeChildSelections="false"/>
-              </constraints>
-            </entryLink>
-            <entryLink import="true" name="Saturnine concussion hammer" hidden="false" id="1d04-8d3d-cfff-17c9" type="selectionEntry" targetId="5245-80e4-d107-3847" sortIndex="3">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="534a-f97b-36ec-2c1b" includeChildSelections="false"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="69fb-fae0-5350-940b" includeChildSelections="false"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="a322-51ad-f1d9-c986" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Assault Squad" hidden="false" id="470d-5d41-cc59-b85b" sortIndex="32">
       <costs>
@@ -5166,7 +5170,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Praetor" hidden="false" id="eebd-52dd-594a-86fb">
+        <selectionEntry type="model" import="true" name="Praetor" hidden="false" id="eebd-52dd-594a-86fb" sortIndex="2">
           <profiles>
             <profile name="Praetor" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="778f-7cd8-3172-9e70">
               <characteristics>
@@ -5244,197 +5248,268 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="91f2-7975-4f8f-abb4" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="0207-0711-4ed4-ba5d" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="8f0a-e21d-a905-e21b" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="3">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a44a-6eef-c6a8-52c3" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Cyber-familiar" hidden="false" id="2abf-e2bd-8f56-6691" type="selectionEntry" targetId="a545-36ec-d50e-2ae4" sortIndex="4">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="aff2-0b86-22f9-a348" includeChildSelections="false"/>
-          </constraints>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="9e29-3097-e7b7-8f26" shared="true"/>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink import="true" name="Prime Unit" hidden="false" id="408d-db4a-41f1-94d8" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
-          <entryLinks>
-            <entryLink import="true" name="Prime Benefits" hidden="false" id="5c2c-c897-4f46-b9eb" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
-          </entryLinks>
-        </entryLink>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="c3e1-6a8a-1dc9-0f57" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
-        <entryLink import="true" name="Breacher Charges" hidden="false" id="1cfa-6833-a012-fcd9" type="selectionEntry" targetId="01bd-4377-904c-6625" sortIndex="6">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1c98-c9a8-d2c9-8f1d"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="true" id="ef28-f458-e409-7f30" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="e966-8af9-6e75-09a8" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="7"/>
-      </entryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="d3ff-0c94-ec92-9fd3" hidden="false" sortIndex="2">
-          <comment>May exchange bolter/bolt pistol for:</comment>
-          <entryLinks>
-            <entryLink import="true" name="Pair of lightning claws" hidden="false" id="8a74-e63a-a3cf-fad7" type="selectionEntry" targetId="6754-24dd-5be0-26ff">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="716a-cd5c-bc17-e9fa" includeChildSelections="false"/>
-              </constraints>
-            </entryLink>
-            <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="b45d-7def-84b5-fefe" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <comment>RG+Cmd Only</comment>
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f39b-c40e-131e-360f"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="6c40-7f93-88b7-cb78" includeChildSelections="false"/>
-          </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolter for:" id="7241-f7af-2c37-bf3b" hidden="false" sortIndex="0">
+            <selectionEntryGroup name="Options" id="d3ff-0c94-ec92-9fd3" hidden="false" sortIndex="2">
+              <comment>May exchange bolter/bolt pistol for:</comment>
               <entryLinks>
-                <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="5463-c3ad-7424-738c" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="3" flatten="true">
+                <entryLink import="true" name="Pair of lightning claws" hidden="false" id="8a74-e63a-a3cf-fad7" type="selectionEntry" targetId="6754-24dd-5be0-26ff">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="716a-cd5c-bc17-e9fa" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="b45d-7def-84b5-fefe" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <comment>RG+Cmd Only</comment>
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f39b-c40e-131e-360f"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="6c40-7f93-88b7-cb78" includeChildSelections="false"/>
+              </constraints>
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolter for:" id="7241-f7af-2c37-bf3b" hidden="false" sortIndex="0">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="5463-c3ad-7424-738c" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="3" flatten="true">
+                      <selectionEntries>
+                        <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="c1d3-b5f1-9574-9fec" sortIndex="2">
+                          <costs>
+                            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
+                            <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                            <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                          </costs>
+                          <entryLinks>
+                            <entryLink import="true" name="Bolter" hidden="false" id="9a64-acd7-6890-946c" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d95b-734d-cc99-0d59" includeChildSelections="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="26fa-22b3-cdf7-476a" includeChildSelections="false"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink import="true" name="Bayonet" hidden="false" id="7e40-98c0-ff0e-fee0" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="836d-ea61-5cf6-b4f3" includeChildSelections="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="35c2-b02e-8b3f-7eac" includeChildSelections="false"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntry>
+                        <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="8ae8-9a3a-f600-9515" sortIndex="4">
+                          <costs>
+                            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                            <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                            <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                          </costs>
+                          <entryLinks>
+                            <entryLink import="true" name="Bolter" hidden="false" id="caa3-da3b-76c2-b766" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="27ab-7e05-5061-15eb" includeChildSelections="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8393-753e-71b6-f814" includeChildSelections="false"/>
+                              </constraints>
+                            </entryLink>
+                            <entryLink import="true" name="Chain bayonet" hidden="false" id="d679-f05f-7fdb-8947" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
+                              <constraints>
+                                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e467-d1da-244b-bb18" includeChildSelections="false"/>
+                                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8e56-6d85-20ab-1c66" includeChildSelections="false"/>
+                              </constraints>
+                            </entryLink>
+                          </entryLinks>
+                        </selectionEntry>
+                      </selectionEntries>
+                      <entryLinks>
+                        <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="false" id="5a4e-93fc-4a25-0642" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
+                          <costs>
+                            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
+                          </costs>
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7d06-65c0-27b5-f225"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="b1e9-1602-cd59-1a11" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
+                          <costs>
+                            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
+                          </costs>
+                          <constraints>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b67a-6316-5aff-3de6"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                      <comment>Exchange bolter for</comment>
+                    </entryLink>
+                    <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="bcec-8244-b1da-3ea6" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08">
+                      <comment>Exchange bolter for</comment>
+                      <modifiers>
+                        <modifier type="set" value="0" field="c6dc-8a79-cc0a-3479"/>
+                      </modifiers>
+                    </entryLink>
+                    <entryLink import="true" name="Volkite charger" hidden="false" id="4904-7ff3-0bab-acea" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="5">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Astartes shotgun" hidden="false" id="cef5-80bb-6815-0fac" type="selectionEntry" targetId="6068-d203-27e6-318a" sortIndex="4">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Paragon blade" hidden="false" id="1d0d-f649-f501-934d" type="selectionEntry" targetId="1881-a2b5-fc58-4270" sortIndex="2">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Archeotech pistol" hidden="false" id="9def-2e81-3cae-8f3a" type="selectionEntry" targetId="0600-3af1-d080-abf7" sortIndex="3">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="3c2d-b890-c128-d87b" includeChildSelections="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f8f4-706a-8e2e-d151"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="0" field="3c2d-b890-c128-d87b">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" value="0" field="f8f4-706a-8e2e-d151">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May exchange Bolt pistol for:" id="2165-7d66-56a4-9a2e" hidden="false" defaultSelectionEntryId="43d6-a430-ef8f-774d" sortIndex="0">
+                  <entryLinks>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="43d6-a430-ef8f-774d" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="1">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+                      </costs>
+                      <modifiers>
+                        <modifier type="set" value="Bolt pistol (default)" field="name"/>
+                      </modifiers>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="true" id="25d6-6ab0-eaac-0ae6" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="6823-0557-2602-4ec2" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Paragon blade" hidden="false" id="1799-4722-c821-9531" type="selectionEntry" targetId="1881-a2b5-fc58-4270" sortIndex="6">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Archeotech pistol" hidden="false" id="a0fe-ad4d-dbb7-a403" type="selectionEntry" targetId="0600-3af1-d080-abf7" sortIndex="7">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="97ab-8f76-e254-2096" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" flatten="true" sortIndex="8">
+                      <comment>Exchange bolt pistol for</comment>
+                    </entryLink>
+                  </entryLinks>
                   <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="c1d3-b5f1-9574-9fec" sortIndex="2">
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="c6c8-c6c5-357a-4bc7" sortIndex="2">
                       <costs>
                         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
                         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
                         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
                       </costs>
                       <entryLinks>
-                        <entryLink import="true" name="Bolter" hidden="false" id="9a64-acd7-6890-946c" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                        <entryLink import="true" name="Bolter" hidden="false" id="e76a-9e33-fc08-553d" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
                           <constraints>
-                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d95b-734d-cc99-0d59" includeChildSelections="false"/>
-                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="26fa-22b3-cdf7-476a" includeChildSelections="false"/>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="98ab-b775-4405-17f9" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5125-fd59-4fcc-f8d5" includeChildSelections="false"/>
                           </constraints>
                         </entryLink>
-                        <entryLink import="true" name="Bayonet" hidden="false" id="7e40-98c0-ff0e-fee0" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
+                        <entryLink import="true" name="Bayonet" hidden="false" id="4fac-4586-6712-03af" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
                           <constraints>
-                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="836d-ea61-5cf6-b4f3" includeChildSelections="false"/>
-                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="35c2-b02e-8b3f-7eac" includeChildSelections="false"/>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7225-b6ce-a596-613f" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8508-5d86-0c07-ad43" includeChildSelections="false"/>
                           </constraints>
                         </entryLink>
                       </entryLinks>
                     </selectionEntry>
-                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="8ae8-9a3a-f600-9515" sortIndex="4">
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="3979-07ab-ac44-56cf" sortIndex="4">
                       <costs>
                         <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
                         <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
                         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
                       </costs>
                       <entryLinks>
-                        <entryLink import="true" name="Bolter" hidden="false" id="caa3-da3b-76c2-b766" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                        <entryLink import="true" name="Bolter" hidden="false" id="e024-fd95-7b39-2522" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
                           <constraints>
-                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="27ab-7e05-5061-15eb" includeChildSelections="false"/>
-                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8393-753e-71b6-f814" includeChildSelections="false"/>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="81fb-8468-ef5a-081a" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4132-96c8-3140-a726" includeChildSelections="false"/>
                           </constraints>
                         </entryLink>
-                        <entryLink import="true" name="Chain bayonet" hidden="false" id="d679-f05f-7fdb-8947" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
+                        <entryLink import="true" name="Chain bayonet" hidden="false" id="236b-454c-e262-a34f" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
                           <constraints>
-                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e467-d1da-244b-bb18" includeChildSelections="false"/>
-                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8e56-6d85-20ab-1c66" includeChildSelections="false"/>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c0d4-2350-08a5-b95b" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6570-e5da-a850-3895" includeChildSelections="false"/>
                           </constraints>
                         </entryLink>
                       </entryLinks>
                     </selectionEntry>
                   </selectionEntries>
-                  <entryLinks>
-                    <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="false" id="5a4e-93fc-4a25-0642" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
-                      <costs>
-                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
-                      </costs>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7d06-65c0-27b5-f225"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="b1e9-1602-cd59-1a11" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
-                      <costs>
-                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
-                      </costs>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b67a-6316-5aff-3de6"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                  <comment>Exchange bolter for</comment>
-                </entryLink>
-                <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="bcec-8244-b1da-3ea6" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08">
-                  <comment>Exchange bolter for</comment>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5790-ded1-b5e8-d738"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6d65-f0ec-f9b4-ca10"/>
+                  </constraints>
                   <modifiers>
-                    <modifier type="set" value="0" field="c6dc-8a79-cc0a-3479"/>
+                    <modifier type="set" value="0" field="5790-ded1-b5e8-d738">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" value="0" field="6d65-f0ec-f9b4-ca10">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
+                            <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
                   </modifiers>
-                </entryLink>
-                <entryLink import="true" name="Volkite charger" hidden="false" id="4904-7ff3-0bab-acea" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="5">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Astartes shotgun" hidden="false" id="cef5-80bb-6815-0fac" type="selectionEntry" targetId="6068-d203-27e6-318a" sortIndex="4">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Paragon blade" hidden="false" id="1d0d-f649-f501-934d" type="selectionEntry" targetId="1881-a2b5-fc58-4270" sortIndex="2">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Archeotech pistol" hidden="false" id="9def-2e81-3cae-8f3a" type="selectionEntry" targetId="0600-3af1-d080-abf7" sortIndex="3">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
-                  </costs>
-                </entryLink>
-              </entryLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="3c2d-b890-c128-d87b" includeChildSelections="false"/>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f8f4-706a-8e2e-d151"/>
-              </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <modifiers>
-                <modifier type="set" value="0" field="3c2d-b890-c128-d87b">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
-                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-                <modifier type="set" value="0" field="f8f4-706a-8e2e-d151">
+                <modifier type="set" value="1" field="6c40-7f93-88b7-cb78">
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
@@ -5446,154 +5521,85 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 </modifier>
               </modifiers>
             </selectionEntryGroup>
-            <selectionEntryGroup name="May exchange Bolt pistol for:" id="2165-7d66-56a4-9a2e" hidden="false" defaultSelectionEntryId="43d6-a430-ef8f-774d" sortIndex="0">
+            <selectionEntryGroup name="Jump Pack" id="899a-215e-b92c-e068" hidden="false" flatten="true" sortIndex="1">
               <entryLinks>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="43d6-a430-ef8f-774d" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="1">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
-                  </costs>
+                <entryLink import="true" name="Corvid Pattern Jump Pack" hidden="true" id="20c1-90d3-5850-726d" type="selectionEntry" targetId="3f94-3ed7-02ee-0c1b" sortIndex="2">
                   <modifiers>
-                    <modifier type="set" value="Bolt pistol (default)" field="name"/>
+                    <modifier type="set" value="false" field="hidden">
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
                   </modifiers>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="true" id="25d6-6ab0-eaac-0ae6" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
                   </costs>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="6823-0557-2602-4ec2" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Paragon blade" hidden="false" id="1799-4722-c821-9531" type="selectionEntry" targetId="1881-a2b5-fc58-4270" sortIndex="6">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Archeotech pistol" hidden="false" id="a0fe-ad4d-dbb7-a403" type="selectionEntry" targetId="0600-3af1-d080-abf7" sortIndex="7">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="97ab-8f76-e254-2096" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" flatten="true" sortIndex="8">
-                  <comment>Exchange bolt pistol for</comment>
                 </entryLink>
               </entryLinks>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="c6c8-c6c5-357a-4bc7" sortIndex="2">
+                <selectionEntry type="upgrade" import="true" name="Jump Pack" hidden="false" id="9e29-3097-e7b7-8f26" sortIndex="1">
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
                     <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
                     <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
                   </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="e76a-9e33-fc08-553d" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="98ab-b775-4405-17f9" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5125-fd59-4fcc-f8d5" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Bayonet" hidden="false" id="4fac-4586-6712-03af" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7225-b6ce-a596-613f" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8508-5d86-0c07-ad43" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="3979-07ab-ac44-56cf" sortIndex="4">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                    <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                    <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-                  </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="e024-fd95-7b39-2522" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="81fb-8468-ef5a-081a" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4132-96c8-3140-a726" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Chain bayonet" hidden="false" id="236b-454c-e262-a34f" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c0d4-2350-08a5-b95b" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6570-e5da-a850-3895" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8201-5bc5-5716-265f" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
               </selectionEntries>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5790-ded1-b5e8-d738"/>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6d65-f0ec-f9b4-ca10"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="0" field="5790-ded1-b5e8-d738">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
-                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-                <modifier type="set" value="0" field="6d65-f0ec-f9b4-ca10">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
-                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
             </selectionEntryGroup>
           </selectionEntryGroups>
-          <modifiers>
-            <modifier type="set" value="1" field="6c40-7f93-88b7-cb78">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="parent" childId="8a74-e63a-a3cf-fad7" shared="true"/>
-                    <condition type="equalTo" value="1" field="selections" scope="parent" childId="b45d-7def-84b5-fefe" shared="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Jump Pack" id="899a-215e-b92c-e068" hidden="false" sortIndex="1" flatten="true">
           <entryLinks>
-            <entryLink import="true" name="Corvid Pattern Jump Pack" hidden="true" id="20c1-90d3-5850-726d" type="selectionEntry" targetId="3f94-3ed7-02ee-0c1b" sortIndex="2">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="8f0a-e21d-a905-e21b" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="3">
               <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Jump Pack" hidden="false" id="9e29-3097-e7b7-8f26" sortIndex="1">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-                <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
               </costs>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8201-5bc5-5716-265f" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a44a-6eef-c6a8-52c3" includeChildSelections="false"/>
               </constraints>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+            </entryLink>
+            <entryLink import="true" name="Cyber-familiar" hidden="false" id="2abf-e2bd-8f56-6691" type="selectionEntry" targetId="a545-36ec-d50e-2ae4" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="aff2-0b86-22f9-a348" includeChildSelections="false"/>
+              </constraints>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="9e29-3097-e7b7-8f26" shared="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="c3e1-6a8a-1dc9-0f57" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+            <entryLink import="true" name="Breacher Charges" hidden="false" id="1cfa-6833-a012-fcd9" type="selectionEntry" targetId="01bd-4377-904c-6625" sortIndex="6">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1c98-c9a8-d2c9-8f1d"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="true" id="ef28-f458-e409-7f30" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
+          </entryLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink import="true" name="Prime Unit" hidden="false" id="408d-db4a-41f1-94d8" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
+          <entryLinks>
+            <entryLink import="true" name="Prime Benefits" hidden="false" id="5c2c-c897-4f46-b9eb" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
+          </entryLinks>
+        </entryLink>
+        <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="e966-8af9-6e75-09a8" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="7"/>
+      </entryLinks>
       <infoLinks>
         <infoLink name="Bulky (X)" id="1513-7bf9-da34-ae24" hidden="true" type="rule" targetId="50ad-a9a5-1f1d-9a25">
           <comment>2</comment>
@@ -5718,61 +5724,97 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
               </conditions>
             </modifier>
           </modifiers>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Terminator Armour" id="e31b-54e3-39ce-9aa9" hidden="false" sortIndex="2">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="6d79-9362-f4b8-039c"/>
-            <selectionEntry type="upgrade" import="true" name="Tartaros" hidden="false" id="1a57-febb-4a60-14fc">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-                <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a31f-fe07-6467-50c5" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d29e-5fe6-5452-05e4" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Options" id="d9a1-0647-971e-242b" hidden="false" flatten="false" sortIndex="3">
           <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange power weapon for:" id="6b11-ddfd-7cac-077b" hidden="false" flatten="false">
-              <entryLinks>
-                <entryLink import="true" name="Legion Terminator Melee Weapons" hidden="false" id="cee5-d3c6-a014-cbed" type="selectionEntryGroup" targetId="0523-46e6-6df1-a4c0" sortIndex="3" flatten="false" collapsible="true"/>
-                <entryLink import="true" name="Power Weapon" hidden="false" id="cebd-502b-439b-5805" type="selectionEntryGroup" targetId="d23f-b4f0-0127-9394" sortIndex="2" collapsible="true" flatten="true"/>
-                <entryLink import="true" name="Paragon blade" hidden="false" id="de2e-168d-fb17-f498" type="selectionEntry" targetId="1881-a2b5-fc58-4270" sortIndex="1">
+            <selectionEntryGroup name="Terminator Armour" id="e31b-54e3-39ce-9aa9" hidden="false" sortIndex="1">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="6d79-9362-f4b8-039c"/>
+                <selectionEntry type="upgrade" import="true" name="Tartaros" hidden="false" id="1a57-febb-4a60-14fc">
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                    <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                    <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
                   </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a31f-fe07-6467-50c5" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d29e-5fe6-5452-05e4" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Options" id="d9a1-0647-971e-242b" hidden="false" flatten="false" sortIndex="2">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange power weapon for:" id="6b11-ddfd-7cac-077b" hidden="false" flatten="false">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Terminator Melee Weapons" hidden="false" id="cee5-d3c6-a014-cbed" type="selectionEntryGroup" targetId="0523-46e6-6df1-a4c0" sortIndex="3" flatten="false" collapsible="true"/>
+                    <entryLink import="true" name="Power Weapon" hidden="false" id="cebd-502b-439b-5805" type="selectionEntryGroup" targetId="d23f-b4f0-0127-9394" sortIndex="2" collapsible="true" flatten="true"/>
+                    <entryLink import="true" name="Paragon blade" hidden="false" id="de2e-168d-fb17-f498" type="selectionEntry" targetId="1881-a2b5-fc58-4270" sortIndex="1">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="15"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a15d-dfde-f09e-c032" includeChildSelections="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="351b-41e0-9cef-c040" includeChildSelections="false"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="0" field="351b-41e0-9cef-c040">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="6754-24dd-5be0-26ff" shared="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May exchange combi-bolter for:" id="e4e4-c969-42be-023f" hidden="false" collapsible="false" flatten="false">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="3ee9-ca75-21de-7d56" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08" sortIndex="3" flatten="false"/>
+                    <entryLink import="true" name="Combi-bolter" hidden="false" id="9268-f724-d807-d41f" type="selectionEntry" targetId="042d-9e60-db9e-c147" defaultAmount="1" sortIndex="1"/>
+                    <entryLink import="true" name="Volkite charger" hidden="false" id="a124-498d-a206-95f3" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="2"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7a49-6223-58ba-605c" includeChildSelections="false"/>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="58be-f881-bebb-bfbf" includeChildSelections="false"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="0" field="58be-f881-bebb-bfbf">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="6754-24dd-5be0-26ff" shared="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink import="true" name="Pair of lightning claws" hidden="false" id="02ae-9941-04ad-36e4" type="selectionEntry" targetId="6754-24dd-5be0-26ff">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7d39-5a9b-7fc7-5e8b" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="9f38-3fce-debf-2447" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <comment>RG+Cmd Only</comment>
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e7de-7d06-50b3-dd17"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a15d-dfde-f09e-c032" includeChildSelections="false"/>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="351b-41e0-9cef-c040" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4b06-1a70-2757-faf1" includeChildSelections="false"/>
               </constraints>
               <modifiers>
-                <modifier type="set" value="0" field="351b-41e0-9cef-c040">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="6754-24dd-5be0-26ff" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="May exchange combi-bolter for:" id="e4e4-c969-42be-023f" hidden="false" collapsible="false" flatten="false">
-              <entryLinks>
-                <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="3ee9-ca75-21de-7d56" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08" sortIndex="3" flatten="false"/>
-                <entryLink import="true" name="Combi-bolter" hidden="false" id="9268-f724-d807-d41f" type="selectionEntry" targetId="042d-9e60-db9e-c147" defaultAmount="1" sortIndex="1"/>
-                <entryLink import="true" name="Volkite charger" hidden="false" id="a124-498d-a206-95f3" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="2"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7a49-6223-58ba-605c" includeChildSelections="false"/>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="58be-f881-bebb-bfbf" includeChildSelections="false"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="0" field="58be-f881-bebb-bfbf">
+                <modifier type="set" value="1" field="4b06-1a70-2757-faf1">
                   <conditions>
                     <condition type="equalTo" value="1" field="selections" scope="unit" childId="6754-24dd-5be0-26ff" shared="true"/>
                   </conditions>
@@ -5781,43 +5823,27 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink import="true" name="Pair of lightning claws" hidden="false" id="02ae-9941-04ad-36e4" type="selectionEntry" targetId="6754-24dd-5be0-26ff">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7d39-5a9b-7fc7-5e8b" includeChildSelections="false"/>
-              </constraints>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="5a03-b6ea-16aa-c722" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="3">
+              <entryLinks>
+                <entryLink import="true" name="Gorgon Terminator Armour" hidden="true" id="3139-d592-6b65-78fe" type="selectionEntry" targetId="a2ba-c8fc-f381-7d22">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="736e-3967-e72b-e3ac" shared="true" includeChildSelections="true"/>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="1a57-febb-4a60-14fc" shared="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e1a2-fe2c-ca77-4735"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
             </entryLink>
-            <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="9f38-3fce-debf-2447" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <comment>RG+Cmd Only</comment>
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e7de-7d06-50b3-dd17"/>
-              </constraints>
-            </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="8dc8-c5af-5e57-91ce" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="4"/>
           </entryLinks>
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="4b06-1a70-2757-faf1" includeChildSelections="false"/>
-          </constraints>
-          <modifiers>
-            <modifier type="set" value="1" field="4b06-1a70-2757-faf1">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="unit" childId="6754-24dd-5be0-26ff" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+        </selectionEntry>
+      </selectionEntries>
       <infoLinks>
         <infoLink name="Implacable Advance" id="1bc5-7873-3b5c-09d2" hidden="false" type="rule" targetId="3898-aafb-35e0-141b"/>
         <infoLink name="Bulky (X)" id="e723-ebe4-2336-48d6" hidden="false" type="rule" targetId="50ad-a9a5-1f1d-9a25">
@@ -5847,37 +5873,12 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
       <categoryLinks>
         <categoryLink targetId="647c-faca-3c98-c203" id="9741-721d-9801-773a" primary="false" name="Free Power Weapon"/>
       </categoryLinks>
-      <modifiers>
-        <modifier type="remove" value="1e7d-9066-28d2-97a0" field="category">
-          <conditions>
-            <condition type="equalTo" value="1" field="selections" scope="unit" childId="1a57-febb-4a60-14fc" shared="true"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <entryLinks>
         <entryLink import="true" name="Prime Unit" hidden="false" id="bc59-528d-4fe6-8573" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="9064-ad16-4ca4-aa5b" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="5a03-b6ea-16aa-c722" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="3">
-          <entryLinks>
-            <entryLink import="true" name="Gorgon Terminator Armour" hidden="true" id="3139-d592-6b65-78fe" type="selectionEntry" targetId="a2ba-c8fc-f381-7d22">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="736e-3967-e72b-e3ac" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="1a57-febb-4a60-14fc" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e1a2-fe2c-ca77-4735"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="8dc8-c5af-5e57-91ce" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
         <entryLink import="true" name="High Command Detachment Choice" hidden="false" id="be9d-d140-21d1-0f59" type="selectionEntryGroup" targetId="969e-8b5b-1410-cfc6" sortIndex="4"/>
       </entryLinks>
     </selectionEntry>
@@ -5888,33 +5889,11 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="08ee-7921-18f9-57fd" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="4">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3372-e18c-b20b-6293" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="c5aa-88ff-304f-47a4" type="selectionEntry" targetId="60e4-ca33-2e68-9afc">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8c2d-56d7-8938-84de" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="435a-1df8-97b9-4063" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="a7e5-1abd-c5c6-8f6b" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1b8b-9981-0670-8c5b" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b27-6956-7f89-6826" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="6de0-08d2-dc12-031a" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="72cd-4a42-726e-3eb1" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="642d-e273-f878-edb1" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="618a-dc66-7c84-e874" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="3a39-a492-a76c-eca3" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6049,228 +6028,252 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="c40d-2035-4aa0-80c6" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="e8af-478c-4a7f-ac4b" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="2ae0-df8c-2afb-3d84" hidden="false" sortIndex="3">
-          <entryLinks>
-            <entryLink import="true" name="Pair of lightning claws" hidden="false" id="699a-6716-d37b-9fe1" type="selectionEntry" targetId="6754-24dd-5be0-26ff" sortIndex="1">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cd01-1772-2a6c-687e" includeChildSelections="false"/>
-              </constraints>
-            </entryLink>
-            <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="f471-22ed-1034-4735" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256" sortIndex="2">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <comment>RG+Cmd Only</comment>
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e9cf-bb67-f32c-0b70"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c52d-4350-e2a7-4f3c" includeChildSelections="false"/>
-          </constraints>
           <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolter for:" id="efb3-1f57-da4a-e2dd" hidden="false">
+            <selectionEntryGroup name="Jump Pack" id="57ce-8dd6-ab9e-8ea7" hidden="false" flatten="true" sortIndex="1">
               <entryLinks>
-                <entryLink import="true" name="Legion Sergeant Melee Weapons" hidden="false" id="f904-47d4-3f7c-4c2b" type="selectionEntryGroup" targetId="b8d7-8ff0-721e-a963" flatten="false" sortIndex="9">
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="612a-9713-f1e9-5ec7" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e" sortIndex="1" defaultAmount="1">
-                      <modifiers>
-                        <modifier type="set" value="Bolter (default)" field="name"/>
-                      </modifiers>
-                    </entryLink>
-                  </entryLinks>
-                  <comment>Exchange bolter for</comment>
-                </entryLink>
-                <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="eff3-f62c-c129-074e" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08" flatten="false" sortIndex="8">
-                  <comment>Exchange bolter for</comment>
-                  <modifiers>
-                    <modifier type="set" value="0" field="c6dc-8a79-cc0a-3479"/>
-                  </modifiers>
-                </entryLink>
-                <entryLink import="true" name="Volkite charger" hidden="false" id="c475-e610-91dc-59ab" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="7">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Astartes shotgun" hidden="false" id="a5ca-94a0-eda8-57b5" type="selectionEntry" targetId="6068-d203-27e6-318a" sortIndex="6">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter" hidden="true" id="d578-0f18-dc2e-8a9d" type="selectionEntry" targetId="69de-4883-efd2-b876" sortIndex="1">
+                <entryLink import="true" name="Corvid Pattern Jump Pack" hidden="true" id="f62d-55f3-bce1-b923" type="selectionEntry" targetId="3f94-3ed7-02ee-0c1b" sortIndex="2">
                   <modifiers>
                     <modifier type="set" value="false" field="hidden">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition type="instanceOf" value="1" field="selections" scope="force" childId="ac06-fcec-b634-5bd9" shared="true" includeChildSelections="true"/>
-                          </conditions>
-                          <comment>SH</comment>
-                          <conditionGroups>
-                            <conditionGroup type="or">
-                              <conditions>
-                                <condition type="atLeast" value="1" field="selections" scope="unit" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
-                                <condition type="atLeast" value="1" field="selections" scope="unit" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
-                              </conditions>
-                            </conditionGroup>
-                          </conditionGroups>
-                        </conditionGroup>
-                      </conditionGroups>
-                      <comment>IW+Cmd/Champ Only</comment>
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                      </conditions>
                     </modifier>
                   </modifiers>
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
                   </costs>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="false" id="0d8f-46e6-b035-1331" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
-                  </costs>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6c0c-6f14-6bb5-f80b"/>
-                  </constraints>
-                </entryLink>
-                <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="28e2-704a-e845-cb07" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
-                  </costs>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8eaa-f06c-3015-a83c"/>
-                  </constraints>
                 </entryLink>
               </entryLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="da36-9131-a8ff-8586" includeChildSelections="false"/>
-              </constraints>
               <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="8d74-7bf8-4d61-451c" sortIndex="2">
+                <selectionEntry type="upgrade" import="true" name="Jump Pack" hidden="false" id="892f-17e7-95d2-75b3" sortIndex="1">
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
                     <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
                     <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
                   </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="2f52-c6c3-241e-0329" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7d62-667e-f41c-4c2a" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f244-0f0a-9c61-f2e4" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Bayonet" hidden="false" id="3915-7a16-f2e7-e92f" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="23b7-3578-ac1b-7e1d" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9890-c4c0-285b-be8b" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="aecf-0fb8-45bc-d12b" sortIndex="4">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
-                    <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                    <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-                  </costs>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="9096-46ca-a55d-e4b1" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bd63-afa4-6cdb-703f" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f268-cef9-a904-0275" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink import="true" name="Chain bayonet" hidden="false" id="1452-9db0-5b6f-1e4c" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
-                      <constraints>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="05d6-c6c1-36b1-01cd" includeChildSelections="false"/>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="af5e-df05-343b-7ea9" includeChildSelections="false"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4be8-8888-0317-2214" includeChildSelections="false"/>
+                  </constraints>
                 </selectionEntry>
               </selectionEntries>
             </selectionEntryGroup>
-            <selectionEntryGroup name="May exchange bolt pistol for:" id="b6ec-6e78-3609-c426" hidden="false" collapsible="true" defaultSelectionEntryId="ba7a-5f18-8283-d35c">
+            <selectionEntryGroup name="Options" id="2ae0-df8c-2afb-3d84" hidden="false" sortIndex="2">
               <entryLinks>
-                <entryLink import="true" name="Legion Sergeant Melee Weapons" hidden="false" id="1c37-d33e-ba28-adc6" type="selectionEntryGroup" targetId="b8d7-8ff0-721e-a963" sortIndex="4" flatten="false">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="8d42-8462-d123-4dcc" includeChildSelections="false"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink import="true" name="Bolt pistol" hidden="false" id="2b30-61de-6629-37e9" type="selectionEntry" targetId="2942-f783-d627-33c5" defaultAmount="1">
-                      <modifiers>
-                        <modifier type="set" value="Bolt pistol (default)" field="name"/>
-                      </modifiers>
-                    </entryLink>
-                  </entryLinks>
-                </entryLink>
-                <entryLink import="true" name="Legion Pistols" hidden="false" id="5a5a-4a03-567d-43cb" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf" sortIndex="3"/>
-                <entryLink import="true" name="Disintegrator pistol" hidden="false" id="bbb6-7d4d-7e23-acd3" type="selectionEntry" targetId="32d1-2c70-882f-9467" sortIndex="2">
+                <entryLink import="true" name="Pair of lightning claws" hidden="false" id="699a-6716-d37b-9fe1" type="selectionEntry" targetId="6754-24dd-5be0-26ff" sortIndex="1">
                   <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
                   </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="cd01-1772-2a6c-687e" includeChildSelections="false"/>
+                  </constraints>
                 </entryLink>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="ba7a-5f18-8283-d35c" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="1"/>
+                <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="f471-22ed-1034-4735" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256" sortIndex="2">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <comment>RG+Cmd Only</comment>
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e9cf-bb67-f32c-0b70"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c2ae-0635-e934-8e41" includeChildSelections="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="c52d-4350-e2a7-4f3c" includeChildSelections="false"/>
               </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <modifiers>
-            <modifier type="set" value="1" field="c52d-4350-e2a7-4f3c">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="parent" childId="6754-24dd-5be0-26ff" shared="true"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" value="1" field="c52d-4350-e2a7-4f3c">
-              <conditions>
-                <condition type="equalTo" value="1" field="selections" scope="parent" childId="ab57-e7ca-3fc7-b256" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Jump Pack" id="57ce-8dd6-ab9e-8ea7" hidden="false" flatten="true" sortIndex="2">
-          <entryLinks>
-            <entryLink import="true" name="Corvid Pattern Jump Pack" hidden="true" id="f62d-55f3-bce1-b923" type="selectionEntry" targetId="3f94-3ed7-02ee-0c1b" sortIndex="2">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolter for:" id="efb3-1f57-da4a-e2dd" hidden="false">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Sergeant Melee Weapons" hidden="false" id="f904-47d4-3f7c-4c2b" type="selectionEntryGroup" targetId="b8d7-8ff0-721e-a963" flatten="false" sortIndex="9">
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="612a-9713-f1e9-5ec7" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e" sortIndex="1" defaultAmount="1">
+                          <modifiers>
+                            <modifier type="set" value="Bolter (default)" field="name"/>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                      <comment>Exchange bolter for</comment>
+                    </entryLink>
+                    <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="eff3-f62c-c129-074e" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08" flatten="false" sortIndex="8">
+                      <comment>Exchange bolter for</comment>
+                      <modifiers>
+                        <modifier type="set" value="0" field="c6dc-8a79-cc0a-3479"/>
+                      </modifiers>
+                    </entryLink>
+                    <entryLink import="true" name="Volkite charger" hidden="false" id="c475-e610-91dc-59ab" type="selectionEntry" targetId="93e7-6a83-1e9e-204a" sortIndex="7">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Astartes shotgun" hidden="false" id="a5ca-94a0-eda8-57b5" type="selectionEntry" targetId="6068-d203-27e6-318a" sortIndex="6">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter" hidden="true" id="d578-0f18-dc2e-8a9d" type="selectionEntry" targetId="69de-4883-efd2-b876" sortIndex="1">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition type="instanceOf" value="1" field="selections" scope="force" childId="ac06-fcec-b634-5bd9" shared="true" includeChildSelections="true"/>
+                              </conditions>
+                              <comment>SH</comment>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition type="atLeast" value="1" field="selections" scope="unit" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
+                                    <condition type="atLeast" value="1" field="selections" scope="unit" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                          <comment>IW+Cmd/Champ Only</comment>
+                        </modifier>
+                      </modifiers>
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter w/ Bayonet" hidden="false" id="0d8f-46e6-b035-1331" type="selectionEntry" targetId="b2c9-7ceb-417d-7e4d" sortIndex="3">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="6"/>
+                      </costs>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6c0c-6f14-6bb5-f80b"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink import="true" name="Banestrike bolter w/ Chain bayonet" hidden="false" id="28e2-704a-e845-cb07" type="selectionEntry" targetId="dcc7-6fd9-e976-f4f2" sortIndex="5">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="7"/>
+                      </costs>
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8eaa-f06c-3015-a83c"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="da36-9131-a8ff-8586" includeChildSelections="false"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Bayonet" hidden="false" id="8d74-7bf8-4d61-451c" sortIndex="2">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="1"/>
+                        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                      </costs>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="2f52-c6c3-241e-0329" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7d62-667e-f41c-4c2a" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f244-0f0a-9c61-f2e4" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Bayonet" hidden="false" id="3915-7a16-f2e7-e92f" type="selectionEntry" targetId="3484-1bd3-cb74-7abe">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="23b7-3578-ac1b-7e1d" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9890-c4c0-285b-be8b" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                    <selectionEntry type="upgrade" import="true" name="Bolter w/ Chain bayonet" hidden="false" id="aecf-0fb8-45bc-d12b" sortIndex="4">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="2"/>
+                        <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                        <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                      </costs>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="9096-46ca-a55d-e4b1" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bd63-afa4-6cdb-703f" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f268-cef9-a904-0275" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink import="true" name="Chain bayonet" hidden="false" id="1452-9db0-5b6f-1e4c" type="selectionEntry" targetId="e410-d998-bd3e-c0ea">
+                          <constraints>
+                            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="05d6-c6c1-36b1-01cd" includeChildSelections="false"/>
+                            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="af5e-df05-343b-7ea9" includeChildSelections="false"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntry>
+                  </selectionEntries>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May exchange bolt pistol for:" id="b6ec-6e78-3609-c426" hidden="false" collapsible="true" defaultSelectionEntryId="ba7a-5f18-8283-d35c">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Sergeant Melee Weapons" hidden="false" id="1c37-d33e-ba28-adc6" type="selectionEntryGroup" targetId="b8d7-8ff0-721e-a963" sortIndex="4" flatten="false">
+                      <constraints>
+                        <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="8d42-8462-d123-4dcc" includeChildSelections="false"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink import="true" name="Bolt pistol" hidden="false" id="2b30-61de-6629-37e9" type="selectionEntry" targetId="2942-f783-d627-33c5" defaultAmount="1">
+                          <modifiers>
+                            <modifier type="set" value="Bolt pistol (default)" field="name"/>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                    </entryLink>
+                    <entryLink import="true" name="Legion Pistols" hidden="false" id="5a5a-4a03-567d-43cb" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf" sortIndex="3"/>
+                    <entryLink import="true" name="Disintegrator pistol" hidden="false" id="bbb6-7d4d-7e23-acd3" type="selectionEntry" targetId="32d1-2c70-882f-9467" sortIndex="2">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="ba7a-5f18-8283-d35c" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="1"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c2ae-0635-e934-8e41" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <modifiers>
-                <modifier type="set" value="false" field="hidden">
+                <modifier type="set" value="1" field="c52d-4350-e2a7-4f3c">
                   <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                    <condition type="equalTo" value="1" field="selections" scope="parent" childId="6754-24dd-5be0-26ff" shared="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="1" field="c52d-4350-e2a7-4f3c">
+                  <conditions>
+                    <condition type="equalTo" value="1" field="selections" scope="parent" childId="ab57-e7ca-3fc7-b256" shared="true"/>
                   </conditions>
                 </modifier>
               </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
-              </costs>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="c5aa-88ff-304f-47a4" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8c2d-56d7-8938-84de" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="435a-1df8-97b9-4063" includeChildSelections="false"/>
+              </constraints>
             </entryLink>
-          </entryLinks>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Jump Pack" hidden="false" id="892f-17e7-95d2-75b3" sortIndex="1">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="a7e5-1abd-c5c6-8f6b" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1b8b-9981-0670-8c5b" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b27-6956-7f89-6826" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="08ee-7921-18f9-57fd" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
               <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-                <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
               </costs>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4be8-8888-0317-2214" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3372-e18c-b20b-6293" includeChildSelections="false"/>
               </constraints>
-            </selectionEntry>
-          </selectionEntries>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="618a-dc66-7c84-e874" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="642d-e273-f878-edb1" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
+          </entryLinks>
+        </selectionEntry>
+      </selectionEntries>
       <modifiers>
         <modifier type="add" value="c504-9dfa-35d3-c98f" field="category">
           <conditionGroups>
@@ -6387,6 +6390,136 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="9871-cb62-5283-2216" id="53ff-870b-45f2-9150" primary="false" name="Command Model Sub-type"/>
             <categoryLink targetId="1e7d-9066-28d2-97a0" id="a2c7-d6b9-408c-b67b" primary="false" name="Heavy Model Sub-Type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Terminator Armour" id="babb-6a3c-da26-f5d3" hidden="false" sortIndex="1">
+              <selectionEntries>
+                <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="2724-c83c-4226-523b">
+                  <modifiers>
+                    <modifier type="add" value="fdce-834f-ead1-31c3" field="category"/>
+                  </modifiers>
+                </selectionEntry>
+                <selectionEntry type="upgrade" import="true" name="Tartaros" hidden="false" id="d4a4-a3f7-f634-4632">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
+                    <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
+                    <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
+                  </costs>
+                  <modifiers>
+                    <modifier type="add" value="86d7-7e47-a0d7-6041" field="category"/>
+                  </modifiers>
+                </selectionEntry>
+              </selectionEntries>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7b85-21b2-80ee-c693" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6faf-741b-901c-b3bb" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Options" id="32df-0b1c-8590-a832" hidden="false" sortIndex="2">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange power weapon for:" id="cd39-9dca-726a-f330" hidden="false">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Terminator Melee Weapons" hidden="false" id="e493-cec5-db91-30a6" type="selectionEntryGroup" targetId="0523-46e6-6df1-a4c0" sortIndex="2"/>
+                    <entryLink import="true" name="Power Weapon" hidden="false" id="9a33-3148-1a2c-0d76" type="selectionEntryGroup" targetId="d23f-b4f0-0127-9394" sortIndex="1" collapsible="true"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="12a7-2136-d1df-d59a" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May exchange combi-bolter for:" id="45ab-2eb6-97dd-4a71" hidden="false" collapsible="false">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="9eed-4549-5860-c7f0" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08">
+                      <entryLinks>
+                        <entryLink import="true" name="Combi-bolter" hidden="false" id="5133-2aed-17d9-6aa5" type="selectionEntry" targetId="042d-9e60-db9e-c147" defaultAmount="1"/>
+                        <entryLink import="true" name="Volkite charger" hidden="false" id="4c53-a5ad-ddfc-8bc9" type="selectionEntry" targetId="93e7-6a83-1e9e-204a"/>
+                      </entryLinks>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8177-5acf-0841-08b6" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+              <entryLinks>
+                <entryLink import="true" name="Pair of lightning claws" hidden="false" id="ea06-7c53-2118-f2c4" type="selectionEntry" targetId="6754-24dd-5be0-26ff" sortIndex="1">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3eaa-2da9-dfd2-1d2f" includeChildSelections="false"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="a7b6-e148-cb9e-82d8" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256" sortIndex="2">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <comment>RG+Cmd Only</comment>
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                  </costs>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b153-0b23-c605-924b"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Phoenix power spear" hidden="true" id="3015-dd0d-c5b3-6780" type="selectionEntry" targetId="41b7-f368-f337-d940" sortIndex="3">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="eb48-9812-af4c-6912" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="set" value="1" field="e0d0-3d13-0c71-14f9">
+                      <conditions>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="eb48-9812-af4c-6912" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="e0d0-3d13-0c71-14f9"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5021-b7ce-a97f-4f04"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="9ef8-f0f4-9149-ea74" includeChildSelections="false"/>
+              </constraints>
+              <modifiers>
+                <modifier type="set" value="1" field="9ef8-f0f4-9149-ea74">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="6754-24dd-5be0-26ff" shared="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="eb48-9812-af4c-6912" shared="true" includeChildSelections="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9c02-179d-ff5c-84c6" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="3">
+              <entryLinks>
+                <entryLink import="true" name="Gorgon Terminator Armour" hidden="true" id="6466-90fc-51be-9aed" type="selectionEntry" targetId="a2ba-c8fc-f381-7d22">
+                  <modifiers>
+                    <modifier type="set" value="false" field="hidden">
+                      <conditions>
+                        <condition type="instanceOf" value="1" field="selections" scope="force" childId="736e-3967-e72b-e3ac" shared="true" includeChildSelections="true"/>
+                        <condition type="atLeast" value="1" field="selections" scope="parent" childId="1a57-febb-4a60-14fc" shared="true"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f048-bb24-2797-2401"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="5b89-0eec-1218-2a42" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="4"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -6424,116 +6557,6 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </infoLink>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Terminator Armour" id="babb-6a3c-da26-f5d3" hidden="false" sortIndex="2">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="2724-c83c-4226-523b">
-              <modifiers>
-                <modifier type="add" value="fdce-834f-ead1-31c3" field="category"/>
-              </modifiers>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tartaros" hidden="false" id="d4a4-a3f7-f634-4632">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
-                <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
-                <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
-              </costs>
-              <modifiers>
-                <modifier type="add" value="86d7-7e47-a0d7-6041" field="category"/>
-              </modifiers>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7b85-21b2-80ee-c693" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6faf-741b-901c-b3bb" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Options" id="32df-0b1c-8590-a832" hidden="false" sortIndex="3">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange power weapon for:" id="cd39-9dca-726a-f330" hidden="false">
-              <entryLinks>
-                <entryLink import="true" name="Legion Terminator Melee Weapons" hidden="false" id="e493-cec5-db91-30a6" type="selectionEntryGroup" targetId="0523-46e6-6df1-a4c0" sortIndex="2"/>
-                <entryLink import="true" name="Power Weapon" hidden="false" id="9a33-3148-1a2c-0d76" type="selectionEntryGroup" targetId="d23f-b4f0-0127-9394" sortIndex="1" collapsible="true"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="12a7-2136-d1df-d59a" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="May exchange combi-bolter for:" id="45ab-2eb6-97dd-4a71" hidden="false" collapsible="false">
-              <entryLinks>
-                <entryLink import="true" name="Legion Combi-weapons" hidden="false" id="9eed-4549-5860-c7f0" type="selectionEntryGroup" targetId="f335-622e-6b0a-6b08">
-                  <entryLinks>
-                    <entryLink import="true" name="Combi-bolter" hidden="false" id="5133-2aed-17d9-6aa5" type="selectionEntry" targetId="042d-9e60-db9e-c147" defaultAmount="1"/>
-                    <entryLink import="true" name="Volkite charger" hidden="false" id="4c53-a5ad-ddfc-8bc9" type="selectionEntry" targetId="93e7-6a83-1e9e-204a"/>
-                  </entryLinks>
-                </entryLink>
-              </entryLinks>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8177-5acf-0841-08b6" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink import="true" name="Pair of lightning claws" hidden="false" id="ea06-7c53-2118-f2c4" type="selectionEntry" targetId="6754-24dd-5be0-26ff" sortIndex="1">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3eaa-2da9-dfd2-1d2f" includeChildSelections="false"/>
-              </constraints>
-            </entryLink>
-            <entryLink import="true" name="Pair of Raven&apos;s Talons" hidden="true" id="a7b6-e148-cb9e-82d8" type="selectionEntry" targetId="ab57-e7ca-3fc7-b256" sortIndex="2">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <comment>RG+Cmd Only</comment>
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="340c-1d4f-1f31-fb70" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-              </costs>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b153-0b23-c605-924b"/>
-              </constraints>
-            </entryLink>
-            <entryLink import="true" name="Phoenix power spear" hidden="true" id="3015-dd0d-c5b3-6780" type="selectionEntry" targetId="41b7-f368-f337-d940" sortIndex="3">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="eb48-9812-af4c-6912" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="1" field="e0d0-3d13-0c71-14f9">
-                  <conditions>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="eb48-9812-af4c-6912" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="e0d0-3d13-0c71-14f9"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5021-b7ce-a97f-4f04"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="9ef8-f0f4-9149-ea74" includeChildSelections="false"/>
-          </constraints>
-          <modifiers>
-            <modifier type="set" value="1" field="9ef8-f0f4-9149-ea74">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="6754-24dd-5be0-26ff" shared="true"/>
-                    <condition type="equalTo" value="1" field="selections" scope="parent" childId="eb48-9812-af4c-6912" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <categoryLinks>
         <categoryLink targetId="647c-faca-3c98-c203" id="dc72-70e2-8cd7-446d" primary="false" name="Free Power Weapon"/>
         <categoryLink targetId="901a-6b71-7a29-4597" id="2220-5980-1c3b-aca5" primary="false" name="Officer of the Line (2)"/>
@@ -6549,24 +6572,6 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <entryLink import="true" name="Prime Unit" hidden="false" id="0462-0809-0ad6-230e" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="7906-cbaa-cc6a-a203" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
-          </entryLinks>
-        </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="5b89-0eec-1218-2a42" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9c02-179d-ff5c-84c6" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="4">
-          <entryLinks>
-            <entryLink import="true" name="Gorgon Terminator Armour" hidden="true" id="6466-90fc-51be-9aed" type="selectionEntry" targetId="a2ba-c8fc-f381-7d22">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="736e-3967-e72b-e3ac" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="parent" childId="1a57-febb-4a60-14fc" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f048-bb24-2797-2401"/>
-              </constraints>
-            </entryLink>
           </entryLinks>
         </entryLink>
       </entryLinks>
@@ -6598,6 +6603,75 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="aa5a-c9fd-1eb1-7a45" id="11fe-1937-4f74-b389" primary="false" name="Vehicle Model Type"/>
             <categoryLink targetId="2e6d-36f6-eeca-8e0c" id="4e2a-a306-4580-8dcf" primary="false" name="Transport Model Sub-Type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="9a3a-fd9c-660e-209a" hidden="false" sortIndex="1">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="Replace Pintle Mounted bolter #1 with:" id="12e5-5718-5cc1-80ea" hidden="false" defaultSelectionEntryId="562f-d90e-7f9a-86d3" sortIndex="2">
+                  <entryLinks>
+                    <entryLink import="true" name="Combi-bolter" hidden="false" id="ba75-6ba8-5fef-1690" type="selectionEntry" targetId="042d-9e60-db9e-c147">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                      </costs>
+                      <modifiers>
+                        <modifier type="set" value="Pintle Mounted combi-bolter" field="name"/>
+                      </modifiers>
+                    </entryLink>
+                    <entryLink import="true" name="Bolter" hidden="false" id="562f-d90e-7f9a-86d3" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
+                      <modifiers>
+                        <modifier type="set" value="Pintle Mounted bolter" field="name"/>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="62d3-1d7a-4eec-a8db" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d1f7-e6a1-32ce-c130" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="Replace Pintle Mounted bolter #2 with:" id="5e59-2948-37bf-3b14" hidden="false" sortIndex="3">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Pintle Weapons" hidden="false" id="b38c-91af-c5f4-ee32" type="selectionEntryGroup" targetId="d625-37d6-d83a-0de3">
+                      <entryLinks>
+                        <entryLink import="true" name="Bolter" hidden="false" id="b7d7-30bc-475b-4a25" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e" defaultAmount="1">
+                          <modifiers>
+                            <modifier type="set" value="Pintle Mounted bolter" field="name"/>
+                          </modifiers>
+                        </entryLink>
+                      </entryLinks>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1d52-bf87-aa78-2992" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4c7d-f77b-c8d5-96c9" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May take any of the following:" id="952c-1102-1d63-4020" hidden="false" sortIndex="1">
+                  <entryLinks>
+                    <entryLink import="true" name="Searchlight" hidden="false" id="b3e5-3903-3330-8fa8" type="selectionEntry" targetId="5a85-bf28-f790-7bf0" sortIndex="1">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Hunter-killer missile" hidden="false" id="e517-c0dc-8b8e-056e" type="selectionEntry" targetId="b9b7-8297-35b5-74ad" sortIndex="2">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                      </costs>
+                      <modifiers>
+                        <modifier type="set" value="Hull (Front) Mounted hunter-killer missile" field="name"/>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Command vox relay" hidden="false" id="1092-a0c1-578f-9f11" type="selectionEntry" targetId="2012-4b76-43b0-c7dd" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="93a6-88de-8266-f681" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="57f3-0281-4726-4880" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -6613,74 +6687,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </infoLink>
         <infoLink name="Mobile Command Vehicle" id="c623-24ce-078f-54db" hidden="false" type="rule" targetId="799f-1773-d0ae-d423"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="9a3a-fd9c-660e-209a" hidden="false" sortIndex="1">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Replace Pintle Mounted bolter #1 with:" id="12e5-5718-5cc1-80ea" hidden="false" defaultSelectionEntryId="562f-d90e-7f9a-86d3" sortIndex="2">
-              <entryLinks>
-                <entryLink import="true" name="Combi-bolter" hidden="false" id="ba75-6ba8-5fef-1690" type="selectionEntry" targetId="042d-9e60-db9e-c147">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-                  </costs>
-                  <modifiers>
-                    <modifier type="set" value="Pintle Mounted combi-bolter" field="name"/>
-                  </modifiers>
-                </entryLink>
-                <entryLink import="true" name="Bolter" hidden="false" id="562f-d90e-7f9a-86d3" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e">
-                  <modifiers>
-                    <modifier type="set" value="Pintle Mounted bolter" field="name"/>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="62d3-1d7a-4eec-a8db" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d1f7-e6a1-32ce-c130" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="Replace Pintle Mounted bolter #2 with:" id="5e59-2948-37bf-3b14" hidden="false" sortIndex="3">
-              <entryLinks>
-                <entryLink import="true" name="Legion Pintle Weapons" hidden="false" id="b38c-91af-c5f4-ee32" type="selectionEntryGroup" targetId="d625-37d6-d83a-0de3">
-                  <entryLinks>
-                    <entryLink import="true" name="Bolter" hidden="false" id="b7d7-30bc-475b-4a25" type="selectionEntry" targetId="d3f9-b9e6-3ea5-cc8e" defaultAmount="1">
-                      <modifiers>
-                        <modifier type="set" value="Pintle Mounted bolter" field="name"/>
-                      </modifiers>
-                    </entryLink>
-                  </entryLinks>
-                </entryLink>
-              </entryLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1d52-bf87-aa78-2992" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4c7d-f77b-c8d5-96c9" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="May take any of the following:" id="952c-1102-1d63-4020" hidden="false" sortIndex="1">
-              <entryLinks>
-                <entryLink import="true" name="Searchlight" hidden="false" id="b3e5-3903-3330-8fa8" type="selectionEntry" targetId="5a85-bf28-f790-7bf0" sortIndex="1">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Hunter-killer missile" hidden="false" id="e517-c0dc-8b8e-056e" type="selectionEntry" targetId="b9b7-8297-35b5-74ad" sortIndex="2">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-                  </costs>
-                  <modifiers>
-                    <modifier type="set" value="Hull (Front) Mounted hunter-killer missile" field="name"/>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <entryLinks>
-        <entryLink import="true" name="Command vox relay" hidden="false" id="1092-a0c1-578f-9f11" type="selectionEntry" targetId="2012-4b76-43b0-c7dd">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="93a6-88de-8266-f681" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="57f3-0281-4726-4880" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="ca37-c978-03cf-6ed6" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="8dd6-6e25-8210-fa3a" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
@@ -6695,34 +6702,14 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Force Weapon" hidden="false" id="8389-3ba1-c3cc-80bf" type="selectionEntryGroup" targetId="89e6-2502-2486-71f4" sortIndex="1">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3cf6-7c83-8acd-5e6b" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8dd0-83eb-737e-e4ec" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="3f0b-b6b4-dfb7-b53f" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7e14-50d7-2744-e3f8" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dadc-a73a-d1c5-ec2e" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="5dd8-b5d3-3b0d-7378" type="selectionEntry" targetId="60e4-ca33-2e68-9afc">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d40b-7c93-5443-4c8c" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="34f4-60ef-8e0e-2a42" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="c549-5419-af02-aa7b" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="2cec-e9e5-5442-7228" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="d2ac-2e5a-9d09-eafa" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="db94-a4fe-3a9e-1e15" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="3"/>
       </entryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Librarian" hidden="false" id="c0e4-eabd-4f0a-23ca">
+        <selectionEntry type="model" import="true" name="Librarian" hidden="false" id="c0e4-eabd-4f0a-23ca" sortIndex="1">
           <profiles>
             <profile name="Librarian" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="430f-9109-0fc4-4823">
               <characteristics>
@@ -6787,76 +6774,98 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="ab50-49e2-4b87-861d" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="91d3-27e2-41b3-8881" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="41c1-b2ee-9287-47b6" hidden="false" sortIndex="2">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolt pistol for:" id="bb1f-a9b8-5fda-d54a" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3">
-              <entryLinks>
-                <entryLink import="true" name="Legion Pistols" hidden="false" id="ab27-788e-eb30-c9e2" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="6613-0a97-885f-94a0" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
-              </entryLinks>
+          <entryLinks>
+            <entryLink import="true" name="Force Weapon" hidden="false" id="8389-3ba1-c3cc-80bf" type="selectionEntryGroup" targetId="89e6-2502-2486-71f4" sortIndex="1">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2df9-5d25-c45c-4194" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="559a-5b05-bcc4-b6f5" includeChildSelections="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3cf6-7c83-8acd-5e6b" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8dd0-83eb-737e-e4ec" includeChildSelections="false"/>
               </constraints>
+            </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="5dd8-b5d3-3b0d-7378" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d40b-7c93-5443-4c8c" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="34f4-60ef-8e0e-2a42" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="3f0b-b6b4-dfb7-b53f" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7e14-50d7-2744-e3f8" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dadc-a73a-d1c5-ec2e" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="db94-a4fe-3a9e-1e15" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="d2ac-2e5a-9d09-eafa" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
+          </entryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="41c1-b2ee-9287-47b6" hidden="false" sortIndex="2">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolt pistol for:" id="bb1f-a9b8-5fda-d54a" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Pistols" hidden="false" id="ab27-788e-eb30-c9e2" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="6613-0a97-885f-94a0" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2df9-5d25-c45c-4194" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="559a-5b05-bcc4-b6f5" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+            <selectionEntryGroup name="Psychic Disciplines" id="a8ff-5c92-6af0-b976" hidden="false" sortIndex="6">
+              <constraints>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="7442-fccc-1675-e592"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Biomancy" hidden="false" id="1ae7-7fc2-9d08-445e" type="selectionEntry" targetId="d821-8e11-a0be-8327" sortIndex="1">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3471-5e74-eba5-dbc0"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="20" field="9893-c379-920b-8982"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Pyromancy" hidden="false" id="c2c0-e2cc-4259-a64c" type="selectionEntry" targetId="27b2-de8f-1d2c-bd83" sortIndex="2">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f958-fd2b-d8eb-8832"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="10" field="9893-c379-920b-8982"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Telekinesis" hidden="false" id="a44c-9d76-0cd9-6fe1" type="selectionEntry" targetId="a81f-1a6b-8a71-4dd6" sortIndex="3">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="81bf-5340-f57f-6b7b"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="20" field="9893-c379-920b-8982"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Divination" hidden="false" id="4ac4-8068-7c07-cc3d" type="selectionEntry" targetId="9934-8bea-0a00-2ec8" sortIndex="4">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="13da-5422-7eea-e81e"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="20" field="9893-c379-920b-8982"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Thaumaturgy" hidden="false" id="a41d-34e8-b404-d74d" type="selectionEntry" targetId="6822-29f6-efad-7b57" sortIndex="5">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f69-dc0b-b12a-4310"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Telepathy" hidden="false" id="cf05-9d2a-2dd6-efe9" type="selectionEntry" targetId="e09e-1438-3205-2a57" sortIndex="6">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d93f-c158-962a-50ba"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="set" value="10" field="9893-c379-920b-8982"/>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
-        </selectionEntryGroup>
-        <selectionEntryGroup name="Psychic Disciplines" id="a8ff-5c92-6af0-b976" hidden="false">
-          <constraints>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="7442-fccc-1675-e592"/>
-          </constraints>
-          <entryLinks>
-            <entryLink import="true" name="Biomancy" hidden="false" id="1ae7-7fc2-9d08-445e" type="selectionEntry" targetId="d821-8e11-a0be-8327" sortIndex="1">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3471-5e74-eba5-dbc0"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="20" field="9893-c379-920b-8982"/>
-              </modifiers>
-            </entryLink>
-            <entryLink import="true" name="Pyromancy" hidden="false" id="c2c0-e2cc-4259-a64c" type="selectionEntry" targetId="27b2-de8f-1d2c-bd83" sortIndex="2">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f958-fd2b-d8eb-8832"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="10" field="9893-c379-920b-8982"/>
-              </modifiers>
-            </entryLink>
-            <entryLink import="true" name="Telekinesis" hidden="false" id="a44c-9d76-0cd9-6fe1" type="selectionEntry" targetId="a81f-1a6b-8a71-4dd6" sortIndex="3">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="81bf-5340-f57f-6b7b"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="20" field="9893-c379-920b-8982"/>
-              </modifiers>
-            </entryLink>
-            <entryLink import="true" name="Divination" hidden="false" id="4ac4-8068-7c07-cc3d" type="selectionEntry" targetId="9934-8bea-0a00-2ec8" sortIndex="4">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="13da-5422-7eea-e81e"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="20" field="9893-c379-920b-8982"/>
-              </modifiers>
-            </entryLink>
-            <entryLink import="true" name="Thaumaturgy" hidden="false" id="a41d-34e8-b404-d74d" type="selectionEntry" targetId="6822-29f6-efad-7b57" sortIndex="5">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f69-dc0b-b12a-4310"/>
-              </constraints>
-            </entryLink>
-            <entryLink import="true" name="Telepathy" hidden="false" id="cf05-9d2a-2dd6-efe9" type="selectionEntry" targetId="e09e-1438-3205-2a57" sortIndex="6">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d93f-c158-962a-50ba"/>
-              </constraints>
-              <modifiers>
-                <modifier type="set" value="10" field="9893-c379-920b-8982"/>
-              </modifiers>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+        </selectionEntry>
+      </selectionEntries>
       <infoLinks>
         <infoLink name="[Legiones Astartes]" id="fea2-69c5-ba05-6643" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
         <infoLink name="[Allegiance]" id="c51f-c69e-24f6-cdfd" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6870,39 +6879,11 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="2351-dc11-4531-6888" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="1">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bdb1-4639-86bd-895b" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="cc65-b745-35d1-e7e7" type="selectionEntry" targetId="60e4-ca33-2e68-9afc">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1662-f878-1389-97e9" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="97f8-3a5f-7c6d-600f" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="7497-005a-3e80-7ed7" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fee8-3455-8e5e-ae1d" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="68db-a3f8-1397-5ef4" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Paragon blade" hidden="false" id="f037-8958-25ac-6aa9" type="selectionEntry" targetId="1881-a2b5-fc58-4270">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="76c1-c6cd-c262-5b3d" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="39b8-1eda-fd68-e5b7" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="a768-cafe-808e-62fd" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="867e-9671-a2c8-3298" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="9d42-3a8a-a947-09bd" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="8ef7-7e18-02bc-b5fa" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="2"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="6a0a-f0fe-c889-8a8a" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -6975,24 +6956,54 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="7d4b-1804-4054-a501" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="6218-2dd9-4202-b426" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
+          <entryLinks>
+            <entryLink import="true" name="Paragon blade" hidden="false" id="f037-8958-25ac-6aa9" type="selectionEntry" targetId="1881-a2b5-fc58-4270" sortIndex="1">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="76c1-c6cd-c262-5b3d" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="39b8-1eda-fd68-e5b7" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="cc65-b745-35d1-e7e7" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1662-f878-1389-97e9" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="97f8-3a5f-7c6d-600f" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="7497-005a-3e80-7ed7" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fee8-3455-8e5e-ae1d" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="68db-a3f8-1397-5ef4" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="2351-dc11-4531-6888" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bdb1-4639-86bd-895b" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="8ef7-7e18-02bc-b5fa" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="9d42-3a8a-a947-09bd" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
+          </entryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Ranged weapon" id="fef7-5b6d-35b6-8967" hidden="false" defaultSelectionEntryId="a001-5f92-a5b8-e061" sortIndex="2">
+              <entryLinks>
+                <entryLink import="true" name="Volkite serpenta" hidden="false" id="a001-5f92-a5b8-e061" type="selectionEntry" targetId="b7c3-1de1-087c-3d6e" sortIndex="1"/>
+                <entryLink import="true" name="Combi-melta" hidden="false" id="fa1c-792c-ee5c-216b" type="selectionEntry" targetId="9d5c-679f-2b12-9fcc" sortIndex="2">
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7ed4-06e2-ce3c-fbdb" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a15b-cf47-f4ab-c0cf" includeChildSelections="false"/>
+              </constraints>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
         </selectionEntry>
       </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Ranged weapon" id="fef7-5b6d-35b6-8967" hidden="false" defaultSelectionEntryId="a001-5f92-a5b8-e061">
-          <entryLinks>
-            <entryLink import="true" name="Volkite serpenta" hidden="false" id="a001-5f92-a5b8-e061" type="selectionEntry" targetId="b7c3-1de1-087c-3d6e" sortIndex="1"/>
-            <entryLink import="true" name="Combi-melta" hidden="false" id="fa1c-792c-ee5c-216b" type="selectionEntry" targetId="9d5c-679f-2b12-9fcc" sortIndex="2">
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7ed4-06e2-ce3c-fbdb" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a15b-cf47-f4ab-c0cf" includeChildSelections="false"/>
-          </constraints>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <categoryLinks>
         <categoryLink targetId="1baf-b200-9e02-844d" id="1095-dd85-ad6b-3af6" primary="false" name="Legion Champion"/>
       </categoryLinks>
@@ -7007,7 +7018,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <categoryLink targetId="6dbf-654a-f06f-2d69" id="576b-f719-6b95-74da" primary="true" name="Command"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Vigilator" hidden="false" id="5c42-de29-fbf8-7ff1">
+        <selectionEntry type="model" import="true" name="Vigilator" hidden="false" id="5c42-de29-fbf8-7ff1" sortIndex="5">
           <profiles>
             <profile name="Vigilator" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="6583-4291-5772-f9b2">
               <characteristics>
@@ -7072,6 +7083,34 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="9e54-49e8-4889-89bb" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="b9cb-5d8b-4976-a477" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
+          <entryLinks>
+            <entryLink import="true" name="Nemesis rifle" hidden="false" id="421d-9f05-2fdb-e722" type="selectionEntry" targetId="6643-6be5-c3cb-c5e1" sortIndex="1">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="31df-a561-34ed-e59b" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="538d-7acf-89c9-1b0e" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Bolt pistol" hidden="false" id="d222-ee7a-f91e-209d" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="592d-6498-55e2-d09c" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ae2b-6187-84cf-c07b" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="a747-690d-d286-11f2" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9423-60d4-0b45-5912" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8b44-d845-5f3d-3c2f" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="4684-fa11-0709-afcc" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ea1c-40c7-dc2d-e5fc" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c059-4cc9-7c82-c53e" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="8efe-861a-d1fd-23ca" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="dc4d-d2e6-f755-12da" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="6"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -7085,37 +7124,11 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         </infoLink>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="4684-fa11-0709-afcc" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ea1c-40c7-dc2d-e5fc" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c059-4cc9-7c82-c53e" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="a747-690d-d286-11f2" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9423-60d4-0b45-5912" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8b44-d845-5f3d-3c2f" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Bolt pistol" hidden="false" id="d222-ee7a-f91e-209d" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="592d-6498-55e2-d09c" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ae2b-6187-84cf-c07b" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Nemesis rifle" hidden="false" id="421d-9f05-2fdb-e722" type="selectionEntry" targetId="6643-6be5-c3cb-c5e1" sortIndex="1">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="31df-a561-34ed-e59b" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="538d-7acf-89c9-1b0e" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="7d8d-e025-f421-5a25" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="1a41-b7d3-d827-d60e" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="dc4d-d2e6-f755-12da" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="8efe-861a-d1fd-23ca" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Esoterist" hidden="false" id="868f-f32d-d5ef-8021" sortIndex="11">
@@ -7125,7 +7138,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Esoterist" hidden="false" id="189b-d2c3-a824-1b7d">
+        <selectionEntry type="model" import="true" name="Esoterist" hidden="false" id="189b-d2c3-a824-1b7d" sortIndex="1">
           <profiles>
             <profile name="Esoterist" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="1d8a-ecd6-c916-8dd5">
               <characteristics>
@@ -7190,6 +7203,34 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="e642-4e74-43a2-b80d" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="deed-3f4d-42c4-96c7" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
+          <entryLinks>
+            <entryLink import="true" name="Force Weapon" hidden="false" id="b9b7-0707-5a1f-8fb1" type="selectionEntryGroup" targetId="89e6-2502-2486-71f4" sortIndex="1">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="df4f-9663-cec1-97da" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="86d5-ba58-1f90-c948" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Archeotech pistol" hidden="false" id="fc82-f1e0-47f8-c74c" type="selectionEntry" targetId="0600-3af1-d080-abf7" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1eeb-0d74-04c8-8cce" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1ff7-3729-3334-4b0b" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="b418-4d5f-4adb-0e26" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d2e-63b9-ff8f-2aa2" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f0b2-0889-69df-4ad4" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="ee2b-5dcc-0929-bc99" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5c5b-90d5-5b73-774b" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="73ea-e29d-9c66-b195" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="cd92-09af-5605-9c32" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="f5f5-76c2-907d-2dd0" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="6"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
@@ -7200,37 +7241,11 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <infoLink name="Anathemata Discipline" id="693d-d370-e6a6-11e4" hidden="false" type="rule" targetId="f260-e43b-e300-79a6"/>
       </infoLinks>
       <entryLinks>
-        <entryLink import="true" name="Force Weapon" hidden="false" id="b9b7-0707-5a1f-8fb1" type="selectionEntryGroup" targetId="89e6-2502-2486-71f4" sortIndex="1">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="df4f-9663-cec1-97da" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="86d5-ba58-1f90-c948" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Archeotech pistol" hidden="false" id="fc82-f1e0-47f8-c74c" type="selectionEntry" targetId="0600-3af1-d080-abf7" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1eeb-0d74-04c8-8cce" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1ff7-3729-3334-4b0b" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="b418-4d5f-4adb-0e26" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d2e-63b9-ff8f-2aa2" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f0b2-0889-69df-4ad4" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="ee2b-5dcc-0929-bc99" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5c5b-90d5-5b73-774b" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="73ea-e29d-9c66-b195" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="e9cc-817c-2ad4-4155" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="0579-9294-22c2-04bd" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="f5f5-76c2-907d-2dd0" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="cd92-09af-5605-9c32" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
       </entryLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Master of Signals" hidden="false" id="0c1d-e55e-1d4e-ab94" sortIndex="12">
@@ -7240,34 +7255,15 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <entryLinks>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="9320-03b1-9330-28e6" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="efcb-7a0b-b279-7c4e" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="36fa-b209-999e-a4ad" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="aa3b-c901-a977-15af" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ac45-9147-1301-81fc" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d704-d756-304f-23c3" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Command vox relay" hidden="false" id="4d73-abcc-ac37-73e2" type="selectionEntry" targetId="2012-4b76-43b0-c7dd" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b94e-6ebf-6499-9559" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="60cb-1e7d-7956-b15c" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="ef79-f0f9-8ea5-4017" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="3a55-d621-af76-7651" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
         <entryLink import="true" name="Prosperine Arcana" hidden="false" id="c336-56cd-9107-7201" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="c204-eaec-8d5f-7e86" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
       </entryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Master of Signals" hidden="false" id="f985-ac79-b28b-f341">
+        <selectionEntry type="model" import="true" name="Master of Signals" hidden="false" id="f985-ac79-b28b-f341" sortIndex="1">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0c65-8bf0-1bad-58bc" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c0bc-3985-08f6-40e5" includeChildSelections="false"/>
@@ -7332,28 +7328,49 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="6a9d-8247-43bf-99ef" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="3abc-4639-4626-804d" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="e618-9a08-bc18-6696" hidden="false" sortIndex="1">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolt pistol for:" id="b4bc-9025-7a0a-75f3" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Pistols" hidden="false" id="3a20-8fa9-15d6-4946" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="ab02-2ef8-a1aa-e01a" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="90e5-0325-8f35-1c4f" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e13b-0418-e353-6b98" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="9320-03b1-9330-28e6" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="efcb-7a0b-b279-7c4e" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="36fa-b209-999e-a4ad" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="aa3b-c901-a977-15af" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ac45-9147-1301-81fc" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d704-d756-304f-23c3" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Command vox relay" hidden="false" id="4d73-abcc-ac37-73e2" type="selectionEntry" targetId="2012-4b76-43b0-c7dd" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b94e-6ebf-6499-9559" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="60cb-1e7d-7956-b15c" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="c204-eaec-8d5f-7e86" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <infoLinks>
         <infoLink name="[Legiones Astartes]" id="086c-4a25-19c7-ac38" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
         <infoLink name="[Allegiance]" id="26ff-ccc0-f59f-9481" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="e618-9a08-bc18-6696" hidden="false" sortIndex="1">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolt pistol for:" id="b4bc-9025-7a0a-75f3" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3">
-              <entryLinks>
-                <entryLink import="true" name="Legion Pistols" hidden="false" id="3a20-8fa9-15d6-4946" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="ab02-2ef8-a1aa-e01a" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="90e5-0325-8f35-1c4f" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e13b-0418-e353-6b98" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Praevian" hidden="false" id="7bb3-1bf7-ab4b-c34b" sortIndex="13">
       <costs>
@@ -7362,7 +7379,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Praevian" hidden="false" id="0dc7-7704-cfa0-c443">
+        <selectionEntry type="model" import="true" name="Praevian" hidden="false" id="0dc7-7704-cfa0-c443" sortIndex="1">
           <profiles>
             <profile name="Praevian" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="9f88-7b15-eace-4b42">
               <characteristics>
@@ -7427,53 +7444,71 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="6c6f-bed8-451d-8182" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="2df8-8712-4693-8b6d" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="0b3d-819b-6b7d-8107" hidden="false" sortIndex="1">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolt pistol for:" id="7e4f-e30a-1df2-d0b7" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3" sortIndex="2">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Pistols" hidden="false" id="97ad-714f-917b-2d4f" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="7b3a-cec7-fa35-d614" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="23b5-ff93-96ad-fb58" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="289a-b9fb-5e18-dc45" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="96f0-32a4-61be-a9b8" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a730-8a10-383e-6efb" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e6b-8fe2-db0c-1c30" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="6619-a095-13bd-228e" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="68f6-6234-29e6-a4f8" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0f54-884a-5b96-9f7f" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Cortex controller" hidden="false" id="13d3-3d74-a05a-1b46" type="selectionEntry" targetId="e1c7-e5c2-8a4c-1e79" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ca6d-df2c-e0e4-9f0b" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a97c-a1ae-65bb-94ce" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Cyber-familiar" hidden="false" id="f1da-a84d-f153-84ab" type="selectionEntry" targetId="a545-36ec-d50e-2ae4" sortIndex="5">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a042-ef80-0782-9483" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="16a9-a9b6-a257-2389" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="c211-f73e-2b1a-b3d4" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="6">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8e53-3111-2d4c-406e" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="e090-d77f-ad45-d22f" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="7"/>
+            <entryLink import="true" name="Master of Automata" hidden="false" id="23ff-fd90-cb25-0030" type="selectionEntry" targetId="abf3-3d0e-d457-3a59" sortIndex="8">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4ba8-283c-d509-dd3c-min"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4ba8-283c-d509-dd3c-max"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="06fb-09e1-891c-9602" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="9"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="96f0-32a4-61be-a9b8" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a730-8a10-383e-6efb" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e6b-8fe2-db0c-1c30" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="6619-a095-13bd-228e" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="68f6-6234-29e6-a4f8" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0f54-884a-5b96-9f7f" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Cortex controller" hidden="false" id="13d3-3d74-a05a-1b46" type="selectionEntry" targetId="e1c7-e5c2-8a4c-1e79" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ca6d-df2c-e0e4-9f0b" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a97c-a1ae-65bb-94ce" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Cyber-familiar" hidden="false" id="f1da-a84d-f153-84ab" type="selectionEntry" targetId="a545-36ec-d50e-2ae4" sortIndex="5">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a042-ef80-0782-9483" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="16a9-a9b6-a257-2389" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="c211-f73e-2b1a-b3d4" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="6">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8e53-3111-2d4c-406e" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="cf45-abf3-4b66-f9d4" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="2e0c-0719-4705-f195" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
-        </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="06fb-09e1-891c-9602" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="e090-d77f-ad45-d22f" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="7"/>
-        <entryLink import="true" name="Master of Automata" hidden="false" id="23ff-fd90-cb25-0030" type="selectionEntry" targetId="abf3-3d0e-d457-3a59">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4ba8-283c-d509-dd3c-min"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4ba8-283c-d509-dd3c-max"/>
-          </constraints>
         </entryLink>
       </entryLinks>
       <infoLinks>
@@ -7492,22 +7527,6 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
           </modifiers>
         </infoLink>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="0b3d-819b-6b7d-8107" hidden="false" sortIndex="1">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolt pistol for:" id="7e4f-e30a-1df2-d0b7" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3" sortIndex="2">
-              <entryLinks>
-                <entryLink import="true" name="Legion Pistols" hidden="false" id="97ad-714f-917b-2d4f" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="7b3a-cec7-fa35-d614" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="23b5-ff93-96ad-fb58" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="289a-b9fb-5e18-dc45" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Moritat" hidden="false" id="0c28-19c0-71b2-424e" sortIndex="14">
       <costs>
@@ -7516,7 +7535,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Moritat" hidden="false" id="8d59-917b-07c0-6166">
+        <selectionEntry type="model" import="true" name="Moritat" hidden="false" id="8d59-917b-07c0-6166" sortIndex="1">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="183b-ec0a-1d15-d101" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ddc0-1be3-0864-9659" includeChildSelections="false"/>
@@ -7590,42 +7609,63 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="af7d-af64-6b7d-da9d" id="4749-de32-4aa7-8250" primary="false" name="Specialist Model Sub-Type"/>
             <categoryLink targetId="c504-9dfa-35d3-c98f" id="8868-25f8-4662-8598" primary="false" name="Antigrav Model Sub-Type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Ranged weapons" id="349a-9cf9-3e27-b734" hidden="false" defaultSelectionEntryId="4db9-5306-45be-8065" sortIndex="1">
+              <entryLinks>
+                <entryLink import="true" name="Overcharged volkite serpenta" hidden="false" id="4db9-5306-45be-8065" type="selectionEntry" targetId="a3f7-f435-8ad8-05f9" sortIndex="1">
+                  <modifiers>
+                    <modifier type="set" value="Two overcharged volkite serpentas" field="name"/>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Overcharged plasma pistol" hidden="false" id="7f33-1f87-8e54-46c1" type="selectionEntry" targetId="6f6b-2628-9aea-2ffb" sortIndex="2">
+                  <modifiers>
+                    <modifier type="set" value="Two overcharged plasma pistols" field="name"/>
+                  </modifiers>
+                  <costs>
+                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="10d0-e94a-9c6a-4bec" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3aca-1fc4-1888-7797" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f535-2535-32e2-3f78" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="ef00-9929-9336-e8c4" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9f0f-5a0f-b485-a7f5" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="40d2-618d-a7c1-bb98" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Rad grenades" hidden="false" id="c733-6faf-0d6b-c0ac" type="selectionEntry" targetId="cd5f-1eff-df69-6bd2" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dbed-e68a-1315-103d" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bad7-1ba2-56de-5224" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="2019-155b-35f3-8b1e" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c967-4e66-2708-f77d" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9de9-5f17-c2e9-d10e" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7684-62ef-251f-fc12" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="10d0-e94a-9c6a-4bec" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3aca-1fc4-1888-7797" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f535-2535-32e2-3f78" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="ef00-9929-9336-e8c4" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9f0f-5a0f-b485-a7f5" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="40d2-618d-a7c1-bb98" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="2019-155b-35f3-8b1e" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c967-4e66-2708-f77d" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Rad grenades" hidden="false" id="c733-6faf-0d6b-c0ac" type="selectionEntry" targetId="cd5f-1eff-df69-6bd2" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dbed-e68a-1315-103d" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bad7-1ba2-56de-5224" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="51db-996f-2b48-22ed" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="2253-d0fc-f7a5-415d" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="7684-62ef-251f-fc12" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9de9-5f17-c2e9-d10e" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="b01e-114a-47d0-e7e0" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -7643,25 +7683,6 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <infoLink name="Deep Strike" id="63e9-1d8e-9dfd-3189" hidden="false" type="rule" targetId="0553-d06b-52b9-34db"/>
         <infoLink name="Firestorm" id="fcc4-23a9-37fa-a8db" hidden="false" type="rule" targetId="3ed1-c5b3-a98d-1b12"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Ranged weapons" id="349a-9cf9-3e27-b734" hidden="false" sortIndex="1" defaultSelectionEntryId="4db9-5306-45be-8065">
-          <entryLinks>
-            <entryLink import="true" name="Overcharged volkite serpenta" hidden="false" id="4db9-5306-45be-8065" type="selectionEntry" targetId="a3f7-f435-8ad8-05f9" sortIndex="1">
-              <modifiers>
-                <modifier type="set" value="Two overcharged volkite serpentas" field="name"/>
-              </modifiers>
-            </entryLink>
-            <entryLink import="true" name="Overcharged plasma pistol" hidden="false" id="7f33-1f87-8e54-46c1" type="selectionEntry" targetId="6f6b-2628-9aea-2ffb" sortIndex="2">
-              <modifiers>
-                <modifier type="set" value="Two overcharged plasma pistols" field="name"/>
-              </modifiers>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-              </costs>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Siege Breaker" hidden="false" id="8128-2ba6-b677-eb81" sortIndex="15">
       <costs>
@@ -7670,7 +7691,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Siege Breaker" hidden="false" id="6997-2688-bee2-f24b">
+        <selectionEntry type="model" import="true" name="Siege Breaker" hidden="false" id="6997-2688-bee2-f24b" sortIndex="1">
           <profiles>
             <profile name="Siege Breaker" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="c134-47b6-e069-4d52">
               <characteristics>
@@ -7776,22 +7797,8 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="926d-7f83-1f88-f96f" includeChildSelections="false"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Drakenscale" hidden="true" id="4c4c-3ba0-a554-ff33" type="selectionEntry" targetId="b021-e506-1ecd-b3c5" sortIndex="9">
-              <modifiers>
-                <modifier type="set" value="false" field="hidden">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="force" childId="f148-a6e4-5a8c-3aeb" shared="true" includeChildSelections="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="e992-f5c8-4176-748c"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d854-cd58-31d0-9da9"/>
-              </constraints>
-              <costs>
-                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-              </costs>
-            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="a132-7070-7e03-46c1" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="9"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="3cf7-be3a-ac2e-57a7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="10"/>
           </entryLinks>
           <selectionEntryGroups>
             <selectionEntryGroup name="May exchange bolt pistol for:" id="936d-ae02-5b4c-fb2b" hidden="false" defaultSelectionEntryId="20b3-3f38-2825-efa7" sortIndex="1">
@@ -7823,8 +7830,6 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <entryLink import="true" name="Prime Benefits" hidden="false" id="b2ee-6b79-ff15-0166" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="3cf7-be3a-ac2e-57a7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="a132-7070-7e03-46c1" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="fce6-d23c-c7dd-862f" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -7838,7 +7843,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Herald" hidden="false" id="5a0a-4cf9-07bb-cf1c">
+        <selectionEntry type="model" import="true" name="Herald" hidden="false" id="5a0a-4cf9-07bb-cf1c" sortIndex="1">
           <profiles>
             <profile name="Herald" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="a7a3-f701-bc4e-e04e">
               <characteristics>
@@ -7903,121 +7908,123 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="067c-ce9b-488e-8002" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="01c7-a3c3-4e34-a009" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="fc3f-1430-ff97-8c43" hidden="false" sortIndex="1">
-          <entryLinks>
-            <entryLink import="true" name="Power Weapon" hidden="false" id="b88f-3dea-35ea-4903" type="selectionEntryGroup" targetId="d23f-b4f0-0127-9394">
-              <modifiers>
-                <modifier type="set" value="Melee weapon" field="name"/>
-              </modifiers>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="fc3f-1430-ff97-8c43" hidden="false" sortIndex="1">
               <entryLinks>
-                <entryLink import="true" name="Power fist" hidden="false" id="fd2d-94c9-e124-1a37" type="selectionEntry" targetId="2fcc-92a6-d03a-4b55">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Solarite Power Gauntlet" hidden="true" id="9688-99b9-7371-d661" type="selectionEntry" targetId="ddcb-01e9-18af-c8f6">
+                <entryLink import="true" name="Power Weapon" hidden="false" id="b88f-3dea-35ea-4903" type="selectionEntryGroup" targetId="d23f-b4f0-0127-9394">
                   <modifiers>
-                    <modifier type="set" value="false" field="hidden">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <conditions>
-                            <condition type="instanceOf" value="1" field="selections" scope="force" childId="d186-cffc-0950-f632" shared="true" includeChildSelections="true"/>
-                          </conditions>
-                          <comment>IF</comment>
+                    <modifier type="set" value="Melee weapon" field="name"/>
+                  </modifiers>
+                  <entryLinks>
+                    <entryLink import="true" name="Power fist" hidden="false" id="fd2d-94c9-e124-1a37" type="selectionEntry" targetId="2fcc-92a6-d03a-4b55">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Solarite Power Gauntlet" hidden="true" id="9688-99b9-7371-d661" type="selectionEntry" targetId="ddcb-01e9-18af-c8f6">
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
                           <conditionGroups>
-                            <conditionGroup type="or">
+                            <conditionGroup type="and">
                               <conditions>
-                                <condition type="atLeast" value="1" field="selections" scope="unit" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
-                                <condition type="atLeast" value="1" field="selections" scope="unit" childId="af7d-af64-6b7d-da9d" shared="true" includeChildSelections="true"/>
-                                <condition type="atLeast" value="1" field="selections" scope="unit" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
+                                <condition type="instanceOf" value="1" field="selections" scope="force" childId="d186-cffc-0950-f632" shared="true" includeChildSelections="true"/>
                               </conditions>
+                              <comment>IF</comment>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition type="atLeast" value="1" field="selections" scope="unit" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
+                                    <condition type="atLeast" value="1" field="selections" scope="unit" childId="af7d-af64-6b7d-da9d" shared="true" includeChildSelections="true"/>
+                                    <condition type="atLeast" value="1" field="selections" scope="unit" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
-                        </conditionGroup>
-                      </conditionGroups>
-                    </modifier>
-                  </modifiers>
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
-                  </costs>
-                </entryLink>
-                <entryLink import="true" name="Terranic greatsword" hidden="true" id="3bb6-195f-4b45-4f1a" type="selectionEntry" targetId="f1aa-3d18-caac-a960" sortIndex="21">
-                  <costs>
-                    <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-                  </costs>
-                  <modifiers>
-                    <modifier type="set" value="false" field="hidden">
-                      <conditionGroups>
-                        <conditionGroup type="and">
-                          <comment>DA</comment>
-                          <conditions>
-                            <condition type="instanceOf" value="1" field="selections" scope="force" childId="0a35-fce3-188c-b3aa" shared="true" includeChildSelections="true"/>
-                          </conditions>
+                        </modifier>
+                      </modifiers>
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="20"/>
+                      </costs>
+                    </entryLink>
+                    <entryLink import="true" name="Terranic greatsword" hidden="true" id="3bb6-195f-4b45-4f1a" type="selectionEntry" targetId="f1aa-3d18-caac-a960" sortIndex="21">
+                      <costs>
+                        <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+                      </costs>
+                      <modifiers>
+                        <modifier type="set" value="false" field="hidden">
                           <conditionGroups>
-                            <conditionGroup type="or">
+                            <conditionGroup type="and">
+                              <comment>DA</comment>
                               <conditions>
-                                <condition type="atLeast" value="1" field="selections" scope="unit" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
-                                <condition type="atLeast" value="1" field="selections" scope="unit" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
+                                <condition type="instanceOf" value="1" field="selections" scope="force" childId="0a35-fce3-188c-b3aa" shared="true" includeChildSelections="true"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition type="atLeast" value="1" field="selections" scope="unit" childId="9871-cb62-5283-2216" shared="true" includeChildSelections="true"/>
+                                    <condition type="atLeast" value="1" field="selections" scope="unit" childId="5a95-e564-96b2-8dc9" shared="true" includeChildSelections="true"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
-                        </conditionGroup>
-                      </conditionGroups>
-                      <comment>DA+Cmd/Champ Only</comment>
-                    </modifier>
-                  </modifiers>
+                          <comment>DA+Cmd/Champ Only</comment>
+                        </modifier>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9186-bffa-64f9-1487" includeChildSelections="false"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Bolt pistol" hidden="false" id="6c56-41f9-d835-be2d" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="2">
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9186-bffa-64f9-1487" includeChildSelections="false"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="65de-7a8b-e399-928e" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be91-5012-a12e-08e6" includeChildSelections="false"/>
               </constraints>
             </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="d082-01a0-f738-4daa" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d6a2-a0c8-7839-3857" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6263-4f37-e79c-8947" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="bb55-71a7-08df-dc47" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1a8a-18bc-0d91-93bd" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="65a9-2196-cbe6-b5d7" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Icon of Allegiance" hidden="false" id="c935-6837-4d05-e7f6" type="selectionEntry" targetId="b808-6eaa-6396-6ce3" sortIndex="6">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4441-0c91-a7c3-2edf" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="66b3-4a9f-1a57-5784" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="1ba2-e735-d90d-2109" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5e28-de42-e9e0-5833" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="67b0-b445-8457-b5ec" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="7"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="4423-103e-ebe5-95f7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="8"/>
           </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+        </selectionEntry>
+      </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="1ba2-e735-d90d-2109" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="6">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5e28-de42-e9e0-5833" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Bolt pistol" hidden="false" id="6c56-41f9-d835-be2d" type="selectionEntry" targetId="2942-f783-d627-33c5" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="65de-7a8b-e399-928e" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be91-5012-a12e-08e6" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="d082-01a0-f738-4daa" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d6a2-a0c8-7839-3857" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6263-4f37-e79c-8947" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="bb55-71a7-08df-dc47" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1a8a-18bc-0d91-93bd" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="65a9-2196-cbe6-b5d7" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Icon of Allegiance" hidden="false" id="c935-6837-4d05-e7f6" type="selectionEntry" targetId="b808-6eaa-6396-6ce3" sortIndex="5">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4441-0c91-a7c3-2edf" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="66b3-4a9f-1a57-5784" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="7d4d-86a8-6b15-07fe" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="d7f7-f676-e0e9-a950" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="4423-103e-ebe5-95f7" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="67b0-b445-8457-b5ec" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="7"/>
       </entryLinks>
       <infoLinks>
         <infoLink name="[Allegiance]" id="363d-cd4e-6c14-9ef1" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
@@ -8040,7 +8047,7 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Chaplain" hidden="false" id="8616-c46c-fdf2-1751">
+        <selectionEntry type="model" import="true" name="Chaplain" hidden="false" id="8616-c46c-fdf2-1751" sortIndex="1">
           <profiles>
             <profile name="Chaplain" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="3387-8bf6-0a1f-9222">
               <characteristics>
@@ -8105,59 +8112,61 @@ If at any point there are only Rapier Carrier Models remaining in this Unit, tho
             <categoryLink targetId="594d-fa82-13cb-a345" id="6f9b-96bc-4bd6-a507" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="218e-154a-4957-9612" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="265f-5c58-0294-dfa9" hidden="false" sortIndex="1">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolt pistol for:" id="9983-47c4-d91c-26d8" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Pistols" hidden="false" id="05ad-b1d1-fb7d-ab1a" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="8248-cdf8-bd84-eeb3" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b50b-9248-2d9d-095c" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="19dc-a0f2-6f90-b351" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Crozius arcanum" hidden="false" id="976c-f538-d3f1-0530" type="selectionEntry" targetId="4da8-c2aa-1380-9825" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f8b4-e017-be19-9b99" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="33d7-5a9b-dd10-0c8b" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="e771-e3be-4945-76f2" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d2a9-c375-dd5a-fcf8" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="573b-34bd-d13c-3216" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="cf56-b05a-466b-d422" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="44af-9e0f-528c-5099" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1341-dbce-6efe-41e0" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="4e02-b104-585b-ae02" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fa52-56bb-9dde-be92" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="eb74-80e7-7818-bc7d" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="e852-3890-82fd-05a0" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Crozius arcanum" hidden="false" id="976c-f538-d3f1-0530" type="selectionEntry" targetId="4da8-c2aa-1380-9825" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f8b4-e017-be19-9b99" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="33d7-5a9b-dd10-0c8b" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="e771-e3be-4945-76f2" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d2a9-c375-dd5a-fcf8" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="573b-34bd-d13c-3216" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="cf56-b05a-466b-d422" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="44af-9e0f-528c-5099" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1341-dbce-6efe-41e0" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="4e02-b104-585b-ae02" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fa52-56bb-9dde-be92" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="645e-8ed0-e105-272a" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="ec66-1c28-87ea-fd73" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="e852-3890-82fd-05a0" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="eb74-80e7-7818-bc7d" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
       </entryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="265f-5c58-0294-dfa9" hidden="false" sortIndex="1">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolt pistol for:" id="9983-47c4-d91c-26d8" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3">
-              <entryLinks>
-                <entryLink import="true" name="Legion Pistols" hidden="false" id="05ad-b1d1-fb7d-ab1a" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="8248-cdf8-bd84-eeb3" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b50b-9248-2d9d-095c" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="19dc-a0f2-6f90-b351" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <infoLinks>
         <infoLink name="[Allegiance]" id="6183-f0f5-5372-724d" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
         <infoLink name="[Legiones Astartes]" id="9257-0e74-b3b0-40e7" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>
@@ -16436,7 +16445,7 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Master of Descent" hidden="false" id="90ef-262a-8617-be85">
+        <selectionEntry type="model" import="true" name="Master of Descent" hidden="false" id="90ef-262a-8617-be85" sortIndex="1">
           <profiles>
             <profile name="Master of Descent" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="a294-fbdc-f303-f485">
               <characteristics>
@@ -16502,49 +16511,85 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
             <categoryLink targetId="9871-cb62-5283-2216" id="fbbf-6789-41a7-bef7" primary="false" name="Command Model Sub-type"/>
             <categoryLink targetId="c504-9dfa-35d3-c98f" id="51df-6393-4410-98da" primary="false" name="Antigrav Model Sub-Type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="6129-f30d-6942-4d83" hidden="false" sortIndex="1">
+              <entryLinks>
+                <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="f468-16e5-d4d0-5d88" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="1">
+                  <modifiers>
+                    <modifier type="set" value="May exchange chainsword for:" field="name"/>
+                  </modifiers>
+                  <comment>May exchange chainsword for:</comment>
+                  <entryLinks>
+                    <entryLink import="true" name="Chainsword" hidden="false" id="066c-003a-c325-5468" type="selectionEntry" targetId="78f4-4967-2896-c3a5" defaultAmount="1">
+                      <modifiers>
+                        <modifier type="set" value="Chainsword (default)" field="name"/>
+                      </modifiers>
+                      <comment>Default</comment>
+                    </entryLink>
+                  </entryLinks>
+                </entryLink>
+                <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="923f-31c5-b75f-63da" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="2">
+                  <modifiers>
+                    <modifier type="set" value="May exchange bolt pistol for:" field="name"/>
+                  </modifiers>
+                  <entryLinks>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="f8c7-364b-abb0-9d2a" type="selectionEntry" targetId="2942-f783-d627-33c5" defaultAmount="1">
+                      <comment>Default</comment>
+                      <modifiers>
+                        <modifier type="set" value="Bolt pistol (default)" field="name"/>
+                      </modifiers>
+                    </entryLink>
+                  </entryLinks>
+                  <comment>May exchange bolt pistol for:</comment>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Strato-vox" hidden="false" id="8b69-b1ed-43eb-ced7" type="selectionEntry" targetId="e3dd-d327-3f0b-265f" sortIndex="5">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="db4e-4a59-0f17-5abe-min"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="db4e-4a59-0f17-5abe-max"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="4ce5-40fc-2306-8091" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cffb-1a50-cacd-f648" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4cc6-8395-2fe8-013b" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="1345-1a90-7952-ba90" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7e24-2767-7070-529a" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a41c-37c4-04dd-40ae" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="d7c0-6f78-469b-afdd" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bb5c-0a60-f7d1-50c3" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="00ba-1e18-db70-b1fa" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+            <entryLink import="true" name="Breacher Charges" hidden="false" id="7763-d63e-4c88-a816" type="selectionEntry" targetId="01bd-4377-904c-6625" sortIndex="7">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8a2-e8ac-3ed6-bc49"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="aa56-d04e-c2e0-ea57" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="8"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="1345-1a90-7952-ba90" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7e24-2767-7070-529a" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a41c-37c4-04dd-40ae" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="4ce5-40fc-2306-8091" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cffb-1a50-cacd-f648" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4cc6-8395-2fe8-013b" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="d7c0-6f78-469b-afdd" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="5">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bb5c-0a60-f7d1-50c3" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="73cd-bb4b-d5b7-1e9a" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="9ef0-4c4f-7136-a229" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
-        </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="aa56-d04e-c2e0-ea57" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="00ba-1e18-db70-b1fa" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
-        <entryLink import="true" name="Breacher Charges" hidden="false" id="7763-d63e-4c88-a816" type="selectionEntry" targetId="01bd-4377-904c-6625" sortIndex="7">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8a2-e8ac-3ed6-bc49"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Strato-vox" hidden="false" id="8b69-b1ed-43eb-ced7" type="selectionEntry" targetId="e3dd-d327-3f0b-265f" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="db4e-4a59-0f17-5abe-min"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="db4e-4a59-0f17-5abe-max"/>
-          </constraints>
         </entryLink>
       </entryLinks>
       <infoLinks>
@@ -16560,40 +16605,6 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
         <infoLink name="Master of Descent" id="56e2-cc8e-07a1-e6fe" hidden="false" type="rule" targetId="b04c-3f1f-9fac-cd25"/>
         <infoLink name="Tip of the Spear" id="155e-0d2f-1522-fbdb" hidden="false" type="rule" targetId="96e2-c6ab-8084-c1d2"/>
       </infoLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="6129-f30d-6942-4d83" hidden="false" sortIndex="1">
-          <entryLinks>
-            <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="f468-16e5-d4d0-5d88" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="1">
-              <modifiers>
-                <modifier type="set" value="May exchange chainsword for:" field="name"/>
-              </modifiers>
-              <comment>May exchange chainsword for:</comment>
-              <entryLinks>
-                <entryLink import="true" name="Chainsword" hidden="false" id="066c-003a-c325-5468" type="selectionEntry" targetId="78f4-4967-2896-c3a5" defaultAmount="1">
-                  <modifiers>
-                    <modifier type="set" value="Chainsword (default)" field="name"/>
-                  </modifiers>
-                  <comment>Default</comment>
-                </entryLink>
-              </entryLinks>
-            </entryLink>
-            <entryLink import="true" name="Legion Officer Wargear" hidden="false" id="923f-31c5-b75f-63da" type="selectionEntryGroup" targetId="f955-8b22-9362-31c0" sortIndex="2">
-              <modifiers>
-                <modifier type="set" value="May exchange bolt pistol for:" field="name"/>
-              </modifiers>
-              <entryLinks>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="f8c7-364b-abb0-9d2a" type="selectionEntry" targetId="2942-f783-d627-33c5" defaultAmount="1">
-                  <comment>Default</comment>
-                  <modifiers>
-                    <modifier type="set" value="Bolt pistol (default)" field="name"/>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
-              <comment>May exchange bolt pistol for:</comment>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <categoryLinks>
         <categoryLink targetId="ea11-0241-9a96-06a5" id="e21c-b59e-4599-fa6c" primary="false" name="Tip of the Spear"/>
       </categoryLinks>
@@ -16605,7 +16616,7 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
         <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
       </costs>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Overseer" hidden="false" id="288b-6209-b7b2-2f04">
+        <selectionEntry type="model" import="true" name="Overseer" hidden="false" id="288b-6209-b7b2-2f04" sortIndex="1">
           <profiles>
             <profile name="Overseer" typeId="a76f-8e23-8c3e-166d" typeName="Profile" hidden="false" id="7836-42bd-2afe-6be8">
               <characteristics>
@@ -16670,83 +16681,85 @@ Models of any Type other than Vehicle may Embark on a Model with this Special Ru
             <categoryLink targetId="594d-fa82-13cb-a345" id="577a-e396-4916-8069" primary="false" name="Infantry Model Type"/>
             <categoryLink targetId="9871-cb62-5283-2216" id="2e75-5b42-4d93-87e2" primary="false" name="Command Model Sub-type"/>
           </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Options" id="02af-aba0-5bd7-6bd2" hidden="false" sortIndex="1">
+              <selectionEntryGroups>
+                <selectionEntryGroup name="May exchange bolt pistol for:" id="75f6-52f0-6919-8c72" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3" sortIndex="1">
+                  <entryLinks>
+                    <entryLink import="true" name="Legion Pistols" hidden="false" id="9146-2791-1207-66cd" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
+                    <entryLink import="true" name="Bolt pistol" hidden="false" id="ae72-4575-d3cc-823b" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="48c1-c910-1f53-6b8b" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d63f-9a71-179b-22b1" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+                <selectionEntryGroup name="May exchange power lash for:" id="9df3-5bdc-e080-9033" hidden="false" sortIndex="2" defaultSelectionEntryId="cea8-d31e-b534-c092">
+                  <entryLinks>
+                    <entryLink import="true" name="Power lash" hidden="false" id="cea8-d31e-b534-c092" type="selectionEntry" targetId="2198-1efb-d4ef-5907"/>
+                    <entryLink import="true" name="Power maul" hidden="false" id="6f62-d6ea-d786-55f2" type="selectionEntry" targetId="c4fa-659d-bf4b-bad1"/>
+                  </entryLinks>
+                  <constraints>
+                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="77a7-d73d-bb19-0f7e" includeChildSelections="false"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0878-cad1-84c9-dc10" includeChildSelections="false"/>
+                  </constraints>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink import="true" name="Frag grenades" hidden="false" id="2654-ba5a-479c-5909" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2624-c2f0-c812-ff2b" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4d6f-4c38-5ef2-edc5" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Vexilla" hidden="false" id="7c3e-70ee-e893-1a9e" type="selectionEntry" targetId="dfcd-0669-ad43-28aa" sortIndex="5">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
+              </costs>
+              <modifiers>
+                <modifier type="set" value="true" field="hidden">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
+                        <condition type="equalTo" value="1" field="selections" scope="unit" childId="ebe2-88e3-d933-65a4" shared="true"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0180-70f7-2a00-8a85" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Krak grenades" hidden="false" id="4c29-9e8f-a316-ef6b" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0a4a-0dec-254b-ec3d" includeChildSelections="false"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1534-5e2d-c739-4344" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Melta bombs" hidden="false" id="20c3-91c3-315c-7e76" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="4">
+              <costs>
+                <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
+              </costs>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aae-f8ab-a67c-1789" includeChildSelections="false"/>
+              </constraints>
+            </entryLink>
+            <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9e96-13b7-4367-47c7" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="6"/>
+            <entryLink import="true" name="Prosperine Arcana" hidden="false" id="5c10-a253-29c4-7ce6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50" sortIndex="7"/>
+          </entryLinks>
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink import="true" name="Melta bombs" hidden="false" id="20c3-91c3-315c-7e76" type="selectionEntry" targetId="2eb4-687e-a515-ee3d" sortIndex="4">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="5"/>
-          </costs>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8aae-f8ab-a67c-1789" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Vexilla" hidden="false" id="7c3e-70ee-e893-1a9e" type="selectionEntry" targetId="dfcd-0669-ad43-28aa" sortIndex="2">
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="10"/>
-          </costs>
-          <modifiers>
-            <modifier type="set" value="true" field="hidden">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="20c1-90d3-5850-726d" shared="true"/>
-                    <condition type="equalTo" value="1" field="selections" scope="unit" childId="ebe2-88e3-d933-65a4" shared="true"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0180-70f7-2a00-8a85" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Frag grenades" hidden="false" id="2654-ba5a-479c-5909" type="selectionEntry" targetId="60e4-ca33-2e68-9afc" sortIndex="2">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2624-c2f0-c812-ff2b" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4d6f-4c38-5ef2-edc5" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="4c29-9e8f-a316-ef6b" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="3">
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0a4a-0dec-254b-ec3d" includeChildSelections="false"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1534-5e2d-c739-4344" includeChildSelections="false"/>
-          </constraints>
-        </entryLink>
         <entryLink import="true" name="Prime Unit" hidden="false" id="95a5-7917-d040-a6d7" type="selectionEntry" targetId="3fa2-78b1-637f-7fb2">
           <entryLinks>
             <entryLink import="true" name="Prime Benefits" hidden="false" id="2fd9-a1a4-57f2-caba" type="selectionEntryGroup" targetId="a396-b846-c263-6767"/>
           </entryLinks>
         </entryLink>
-        <entryLink import="true" name="Prosperine Arcana" hidden="false" id="5c10-a253-29c4-7ce6" type="selectionEntryGroup" targetId="eafe-beb3-8d27-ec50"/>
-        <entryLink import="true" name="Legion Specific Upgrade" hidden="false" id="9e96-13b7-4367-47c7" type="selectionEntryGroup" targetId="ef74-faa7-0d36-762b" sortIndex="5"/>
       </entryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup name="Options" id="02af-aba0-5bd7-6bd2" hidden="false" sortIndex="1">
-          <selectionEntryGroups>
-            <selectionEntryGroup name="May exchange bolt pistol for:" id="75f6-52f0-6919-8c72" hidden="false" defaultSelectionEntryId="8248-cdf8-bd84-eeb3" sortIndex="1">
-              <entryLinks>
-                <entryLink import="true" name="Legion Pistols" hidden="false" id="9146-2791-1207-66cd" type="selectionEntryGroup" targetId="4041-7fad-77cd-f9cf"/>
-                <entryLink import="true" name="Bolt pistol" hidden="false" id="ae72-4575-d3cc-823b" type="selectionEntry" targetId="2942-f783-d627-33c5"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="48c1-c910-1f53-6b8b" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d63f-9a71-179b-22b1" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-            <selectionEntryGroup name="May exchange power lash for:" id="9df3-5bdc-e080-9033" hidden="false" sortIndex="2" defaultSelectionEntryId="cea8-d31e-b534-c092">
-              <entryLinks>
-                <entryLink import="true" name="Power lash" hidden="false" id="cea8-d31e-b534-c092" type="selectionEntry" targetId="2198-1efb-d4ef-5907"/>
-                <entryLink import="true" name="Power maul" hidden="false" id="6f62-d6ea-d786-55f2" type="selectionEntry" targetId="c4fa-659d-bf4b-bad1"/>
-              </entryLinks>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="77a7-d73d-bb19-0f7e" includeChildSelections="false"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0878-cad1-84c9-dc10" includeChildSelections="false"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <infoLinks>
         <infoLink name="[Allegiance]" id="6082-9959-5c27-280e" hidden="false" type="profile" targetId="bb66-f1f6-4d65-5a07"/>
         <infoLink name="[Legiones Astartes]" id="309e-c970-c78b-3eea" hidden="false" type="profile" targetId="641c-ca0a-7093-4525"/>

--- a/Wargear.cat
+++ b/Wargear.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="fcc7-4319-bb04-2c25" name="Wargear" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="19" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="fcc7-4319-bb04-2c25" name="Wargear" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="20" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Strato-vox" hidden="false" id="e3dd-d327-3f0b-265f">
       <profiles>


### PR DESCRIPTION
Fixes #1110

LA Command Units had all SSE's against the Unit not the Model - this causes any SSE looking for Model is Command Sub-Type to fail as it's looking at the Unit and never finds the Model

Rather than changing the conditions to work around the issue it is better to change the LA Command Units to match the same scheme as all the other Units - Unit -> Model -> SSE/SSEG

<img width="430" height="1119" alt="image" src="https://github.com/user-attachments/assets/dbd8942f-39bc-4a2f-9b25-2a12e84f856e" />
