### PR TITLE
Move Cybertheurgic Statuses from root to shared rules

### DIFF
--- a/Mechanicum.cat
+++ b/Mechanicum.cat
@@ -9813,7 +9813,12 @@ A Unit that includes a Model with this Special Rule may have two Cybertheurgic R
     </entryLink>
   </entryLinks>
   <rules>
-    <rule name="Cybertheugic Status: Null" id="d010-07c3-50a8-4002" hidden="false">
+  </rules>
+  <sharedRules>
+    <rule name="Dispersal Field" id="f50c-2bd5-3de1-4695" hidden="false">
+      <description>A Model with this Special Rule may have the Dispersal Advanced Reaction made for it:</description>
+    </rule>
+        <rule name="Cybertheugic Status: Null" id="d010-07c3-50a8-4002" hidden="false">
       <description>A Model under the effect of this Cybertheugic Status gains no bonuses or penalties - but when Null is applied to any Model in a Unit then all other Cybertheugic Statuses on all Models in that Unit are discarded and the Unit suffers Cybertheugic Feeback immediately regardless of whether any Cybertheugic Statuses are discarded. If a Model in a Unit would gain another Cybertheugic Status while any Models in that Unit have the Null Cybertheugic Status (other than another instance of Null) then it does not gain that Cybertheugic Status, all Models in the Unit discard Null and the Unit suffers Cybertheugic Feedback.</description>
     </rule>
     <rule name="Cybertheugic Status: Quicken" id="1160-e8ac-393e-f60c" hidden="false">
@@ -9824,11 +9829,6 @@ A Unit that includes a Model with this Special Rule may have two Cybertheurgic R
     </rule>
     <rule name="Cybertheugic Status: Guide" id="14b4-336f-014d-f462" hidden="false">
       <description>A Model under the effects of this Cybertheugic Status gains a bonus of +1 to its Ballistic Skill and Weapon Skill Characteristics. If a Model has a Base Weapon Skill or Base Ballistic Skill of 0, then this Cybertheugic Status has no effect on it and it gains no bonuses to any Characteristic from it.</description>
-    </rule>
-  </rules>
-  <sharedRules>
-    <rule name="Dispersal Field" id="f50c-2bd5-3de1-4695" hidden="false">
-      <description>A Model with this Special Rule may have the Dispersal Advanced Reaction made for it:</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Fixes #1136

With the rules in Root they were appearing under every detachment for any force when exporting a list! Now they don't

<img width="1108" height="411" alt="image" src="https://github.com/user-attachments/assets/fb95f837-9a49-4e8f-bafe-1fcda9adfd28" />
