### PR TITLE
Daemons of the Ruinstorm

### DIFF
--- a/Daemons of the Ruinstorm.cat
+++ b/Daemons of the Ruinstorm.cat
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue library="false" id="9396-cc24-458d-d358" name="Daemons of the Ruinstorm" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="53" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="Weapons" id="2707-0b14-8903-f3b3" targetId="a22d-4dd0-c59d-57d3"/>
+    <catalogueLink type="catalogue" name="Wargear" id="e75f-c981-7e6c-24e1" targetId="fcc7-4319-bb04-2c25"/>
+    <catalogueLink type="catalogue" name="Traits" id="e1b8-4d3e-57fe-dae3" targetId="df17-7a05-0826-6e22"/>
+    <catalogueLink type="catalogue" name="Psychic" id="35e8-ac86-2d19-c3dc" targetId="1b2d-2038-39a7-f387"/>
+    <catalogueLink type="catalogue" name="Special Rules" id="d3fb-7301-fdf8-d8b6" targetId="106b-693b-99f2-00c3"/>
+  </catalogueLinks>
+</catalogue>


### PR DESCRIPTION
- [ ] Ætheric Dominions

- [ ] High Command
    - [ ] Ruinstorm Daemon Sovereign

- [ ] Command
    - [ ] Ruinstorm Daemon Hierarch
    - [ ] Ruinstorm Daemon Harbinger

- [ ] Heavy Assault
    - [ ] Ruinstorm Daemon Brutes

- [ ] Troops
    - [ ] Ruinstorm Lesser Daemons
    - [ ] Ruinstorm Daemon Swarms

- [ ] Support
    - [ ] Ruinstorm Greater Daemon Beast
    - [ ] Ruinstorm Daemon Beasts

- [ ] War Engine
    - [ ] Ruinstorm Daemon Behemoth

- [ ] Recon
    - [ ] Ruinstorm Daemon Harriers

- [ ] Fast Attack
    - [ ] Ruinstorm Daemon Riders

- [ ] Lord of War
    - [ ] Ka'bandha
    - [ ] Cor'bax Utterblight
    - [ ] Samus