### PR TITLE
Stormsword missing root entry in SA

### DIFF
--- a/Solar Auxilia.cat
+++ b/Solar Auxilia.cat
@@ -11769,6 +11769,11 @@ While a Unit entirely composed of Models with the Solar Auxilia Trait includes a
         <categoryLink name="Retinue" hidden="false" id="ef01-b69c-ac5f-be0d" targetId="a38e-50ff-310f-f19e" primary="true"/>
       </categoryLinks>
     </entryLink>
+    <entryLink import="true" name="Stormsword Super-heavy Siege Tank" hidden="false" id="9f8d-49a0-1dcb-8011" type="selectionEntry" targetId="5a4f-f6c0-e700-8142">
+      <categoryLinks>
+        <categoryLink targetId="a46f-a465-0ead-d6b8" id="fa6b-2616-e822-b6bf" primary="true" name="Lord of War"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedProfiles>
     <profile name="Iron Tercio" typeId="d5a9-9164-1e30-7a35" typeName="Traits" hidden="false" id="fd91-cc08-8aa0-7d8a">


### PR DESCRIPTION
Fixes #1328

<img width="821" height="776" alt="image" src="https://github.com/user-attachments/assets/42852eb1-3610-431a-857e-2b7c044efe2d" />
