### PR TITLE
Unhide Medusan Vanguard Unlock category

### DIFF
--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -275,7 +275,7 @@
     <categoryEntry name="Heavy Assault - Rampager Squads Only" id="91f0-1b91-0a9a-c542" hidden="false"/>
     <categoryEntry name="Elites - Seeker Squads or Headhunter Kill Teams Only" id="5c0d-4d49-44e2-0a99" hidden="false"/>
     <categoryEntry name="Cohort Additional Detachment" id="27e8-88b4-d3c8-d63f" hidden="false"/>
-    <categoryEntry name="Medusan Vanguard Unlock" id="fc09-911b-ee8c-7967" hidden="true"/>
+    <categoryEntry name="Medusan Vanguard Unlock" id="fc09-911b-ee8c-7967" hidden="false"/>
     <categoryEntry name="Tartaros Centurion" id="86d7-7e47-a0d7-6041" hidden="false">
       <comment>Emperors Children prime check</comment>
     </categoryEntry>


### PR DESCRIPTION
Fixes #1395

I can put a screenshot in here of it not showing an error, but the builder doesn't show an error anyway! The only reason I can think of for this constraint to kick in is that the category is hidden, and therefore it doesn't see it as applying, unhiding it should fix the problem.