### PR TITLE
Move Gorgon Pattern out of Legion Wargear and into Terminator Armour group

### DIFF
--- a/Dark Angels.cat
+++ b/Dark Angels.cat
@@ -3247,17 +3247,6 @@ Models with this Special Rule may never have their Leadership Characteristic mod
       <description>While a Model with both the Dark Angels Trait and either the Paragon Type or Command Sub-Type is part of a Unit that includes any Models with this Special Rule, Precision Wound caused as part of a Shooting Attack cannot be allocated to that Model.</description>
     </rule>
   </sharedRules>
-  <categoryEntries>
-    <categoryEntry name="Artificia Model Type" id="8dd8-e8e9-3c90-05cb" hidden="false" publicationId="5469-14da-d0a1-6092" page="82">
-      <rules>
-        <rule name="Artificia Model Type" id="1262-6cfa-8d01-ff15" hidden="false">
-          <description>The following Rules apply to all Models with the Artificia Type:
-• Models with the Artificia Type cannot gain any Cybertheurgic Statuses, but can gain Tactical Statuses or other kinds of Status effects.
-• When targeting a Unit that includes any Models with the Artificia Type, the effects of the Poisoned (X) Special Rule only trigger on a Wound Test with a result of a ‘6’ before modifiers are applied, regardless of the value of X for that variant of the Special Rule.</description>
-        </rule>
-      </rules>
-    </categoryEntry>
-  </categoryEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Rite of War" id="f49e-6e7b-7b74-252d" hidden="false">
       <selectionEntries>

--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -568,6 +568,15 @@
     <categoryEntry name="Recon - Cavalry Only" id="053a-4e53-7b12-b4ad" hidden="false">
       <comment>Militia</comment>
     </categoryEntry>
+    <categoryEntry name="Artificia Model Type" id="8dd8-e8e9-3c90-05cb" hidden="false" publicationId="5469-14da-d0a1-6092" page="82">
+      <rules>
+        <rule name="Artificia Model Type" id="1262-6cfa-8d01-ff15" hidden="false">
+          <description>The following Rules apply to all Models with the Artificia Type:
+• Models with the Artificia Type cannot gain any Cybertheurgic Statuses, but can gain Tactical Statuses or other kinds of Status effects.
+• When targeting a Unit that includes any Models with the Artificia Type, the effects of the Poisoned (X) Special Rule only trigger on a Wound Test with a result of a ‘6’ before modifiers are applied, regardless of the value of X for that variant of the Special Rule.</description>
+        </rule>
+      </rules>
+    </categoryEntry>
   </categoryEntries>
   <forceEntries>
     <forceEntry name="Crusade Force Organization Chart" id="8562-592c-8d4b-a1f0" hidden="false" childForcesLabel="Detachments" sortIndex="2">

--- a/Wargear.cat
+++ b/Wargear.cat
@@ -999,22 +999,6 @@ Additionally, when a Unit which contains any Models with an ætheric juncture sp
             </modifier>
           </modifiers>
         </entryLink>
-        <entryLink import="true" name="Gorgon Pattern Terminator Armour" hidden="true" id="6466-90fc-51be-9aed" type="selectionEntry" targetId="a2ba-c8fc-f381-7d22">
-          <modifiers>
-            <modifier type="set" value="false" field="hidden">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="force" childId="736e-3967-e72b-e3ac" shared="true" includeChildSelections="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="parent" childId="4041-105d-29a6-2c22" shared="true" includeChildSelections="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f048-bb24-2797-2401"/>
-          </constraints>
-          <costs>
-            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
-          </costs>
-        </entryLink>
         <entryLink import="true" name="Artificia Kill-switch" hidden="true" id="88ef-455b-0ebc-2160" type="selectionEntry" targetId="65d5-d4b2-ab9b-fb96">
           <modifiers>
             <modifier type="set" value="false" field="hidden">
@@ -1022,7 +1006,7 @@ Additionally, when a Unit which contains any Models with an ætheric juncture sp
                 <conditionGroup type="and">
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="force" childId="0a35-fce3-188c-b3aa" shared="true" includeChildSelections="true"/>
-                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="f369-7a8f-853b-fdc5" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                    <condition type="atLeast" value="1" field="selections" scope="roster" childId="8dd8-e8e9-3c90-05cb" shared="true" includeChildSelections="true" includeChildForces="true"/>
                     <condition type="atLeast" value="1" field="forces" scope="roster" childId="8f12-c30a-6c20-6296" shared="true"/>
                     <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="9871-cb62-5283-2216" shared="true"/>
                   </conditions>
@@ -1087,8 +1071,8 @@ Additionally, when a Unit which contains any Models with an ætheric juncture sp
     </selectionEntryGroup>
     <selectionEntryGroup name="Terminator Armour" id="170b-d9c0-e9d6-b314" hidden="false">
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="38a8-2683-c590-3c4b"/>
-        <selectionEntry type="upgrade" import="true" name="Tartaros" hidden="false" id="4041-105d-29a6-2c22">
+        <selectionEntry type="upgrade" import="true" name="Cataphractii" hidden="false" id="38a8-2683-c590-3c4b" sortIndex="1"/>
+        <selectionEntry type="upgrade" import="true" name="Tartaros" hidden="false" id="4041-105d-29a6-2c22" sortIndex="2">
           <costs>
             <cost name="Asset Point(s)" typeId="57e3-1031-7d4d-5ae3" value="0"/>
             <cost name="Reaction Point(s)" typeId="c9ba-097e-c47f-ecc2" value="0"/>
@@ -1101,6 +1085,23 @@ Additionally, when a Unit which contains any Models with an ætheric juncture sp
         <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3c10-67bb-9945-559c" includeChildSelections="false"/>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6eb6-4fa6-4bb5-bc0f" includeChildSelections="false"/>
       </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Gorgon Pattern Terminator Armour" hidden="true" id="6466-90fc-51be-9aed" type="selectionEntry" targetId="a2ba-c8fc-f381-7d22" sortIndex="3">
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="force" childId="736e-3967-e72b-e3ac" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f048-bb24-2797-2401"/>
+          </constraints>
+          <costs>
+            <cost name="Point(s)" typeId="9893-c379-920b-8982" value="30"/>
+          </costs>
+        </entryLink>
+      </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup name="Mount" id="9089-07e5-3653-84b6" hidden="false" defaultSelectionEntryId="4f20-9a87-8334-9f26">
       <selectionEntries>


### PR DESCRIPTION
Fixes #1412

Also fixed Warning in Wargear for Artificia Kill switch that was referencing Excindio directly - moved Artificia category from DA into GST and changed condition from Exindio to Artificia category

<img width="823" height="234" alt="image" src="https://github.com/user-attachments/assets/2449f24e-83a1-4287-bc89-ea54487853a2" />


<img width="1664" height="614" alt="image" src="https://github.com/user-attachments/assets/e98bd9c6-f55a-4e59-8956-d5df3f3ace21" />
