### PR TITLE
Morbius Bombard only shows Phosphex shells profile once selected

### DIFF
--- a/Legiones Astartes.cat
+++ b/Legiones Astartes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="56" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="true" id="9b32-f350-6aa9-9c09" name="Legiones Astartes" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="56" authorName="The4D6" battleScribeVersion="2.03" type="catalogue" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" hidden="false">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Rapier Battery" hidden="false" id="5e1a-86ac-b637-daf2" sortIndex="36">
       <selectionEntries>

--- a/Weapons.cat
+++ b/Weapons.cat
@@ -887,17 +887,6 @@
             <characteristic name="Traits" typeId="1247-79d2-6cc1-8a03"/>
           </characteristics>
         </profile>
-        <profile name="Morbus bombard (Phosphex shell)" typeId="c591-09ed-3e6f-eb2b" typeName="Ranged Weapon" hidden="false" id="3c5e-db01-4a6c-7666">
-          <characteristics>
-            <characteristic name="R" typeId="cdb0-8654-6840-1037">24</characteristic>
-            <characteristic name="FP" typeId="5037-1f27-1790-e355">1</characteristic>
-            <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">5</characteristic>
-            <characteristic name="AP" typeId="7a23-0248-2b94-5951">3</characteristic>
-            <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">1</characteristic>
-            <characteristic name="Special Rules" typeId="5aad-137a-8ee2-63fd">Blast (5&quot;), Barrage (1), Poisoned (3+), Panic (3), Breaching (5+)</characteristic>
-            <characteristic name="Traits" typeId="1247-79d2-6cc1-8a03">Phosphex</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <infoLinks>
         <infoLink name="Blast (X)" id="8203-938c-c9bc-06a7" hidden="false" type="rule" targetId="8687-05f8-7034-412c">
@@ -923,30 +912,6 @@
             <modifier type="set" value="Barrage (2) (HE shell)" field="name"/>
           </modifiers>
           <comment>2 (HE shell)</comment>
-        </infoLink>
-        <infoLink name="Breaching (X)" id="2bd1-b298-051e-4f8d" hidden="false" type="rule" targetId="b094-0b64-eb57-aed6">
-          <modifiers>
-            <modifier type="set" value="Breaching (5+) (Phosphex shell)" field="name"/>
-          </modifiers>
-          <comment>5+ (Phosphex shell)</comment>
-        </infoLink>
-        <infoLink name="Barrage (X)" id="7acf-2248-984a-ea2b" hidden="false" type="rule" targetId="85f5-3a91-69f4-c3b7">
-          <modifiers>
-            <modifier type="set" value="Barrage (1) (Phosphex shell)" field="name"/>
-          </modifiers>
-          <comment>1 (Phosphex shell)</comment>
-        </infoLink>
-        <infoLink name="Panic (X)" id="9607-2373-b41b-b4d0" hidden="false" type="rule" targetId="82a7-f471-3fda-6ca1">
-          <comment>3 (Phosphex shell)</comment>
-          <modifiers>
-            <modifier type="set" value="Panic (3) (Phosphex shell)" field="name"/>
-          </modifiers>
-        </infoLink>
-        <infoLink name="Poisoned (X)" id="baf8-42a1-e3ae-4a58" hidden="false" type="rule" targetId="076f-2c91-c58b-71b3">
-          <comment>3+ (Phosphex shell)</comment>
-          <modifiers>
-            <modifier type="set" value="Poisoned (3+) (Phosphex shell)" field="name"/>
-          </modifiers>
         </infoLink>
       </infoLinks>
     </selectionEntry>


### PR DESCRIPTION
Fixes #1496

<img width="821" height="941" alt="image" src="https://github.com/user-attachments/assets/35eedf16-d698-489a-8cb1-7093769f162a" />
