### PR TITLE
Provide better error messages for Brotherhood of the Phoenix detachment

### DIFF
--- a/Emperor's Children.cat
+++ b/Emperor's Children.cat
@@ -2575,7 +2575,7 @@ After a Shooting Attack that targets a Unit entirely composed of Models with thi
         </modifier>
         <modifier type="add" value="Roster must be at least 3000 points for Brotherhood of the Phoenix" field="error">
           <conditionGroups>
-            <conditionGroup type="or">
+            <conditionGroup type="and">
               <conditions>
                 <condition type="lessThan" value="3000" field="limit::9893-c379-920b-8982" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
                 <condition type="lessThan" value="3000" field="9893-c379-920b-8982" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>


### PR DESCRIPTION
Fixes #1692 
<img width="693" height="117" alt="image" src="https://github.com/user-attachments/assets/9c33eb23-3866-4cbc-8bb2-6b4e72923203" />
