### PR TITLE
Switch round Heavy Conversion Beam profiles so they're in the right order

### DIFF
--- a/Weapons.cat
+++ b/Weapons.cat
@@ -1091,20 +1091,9 @@
     </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Heavy conversion beam cannon" hidden="false" id="4c0a-e911-ab85-2286">
       <profiles>
-        <profile name="Heavy conversion beam cannon (Long)" typeId="c591-09ed-3e6f-eb2b" typeName="Ranged Weapon" hidden="false" id="2e59-2818-48cb-9067">
+        <profile name="Heavy conversion beam cannon (Short)" typeId="c591-09ed-3e6f-eb2b" typeName="Ranged Weapon" hidden="false" id="1b2a-63ff-58d7-0a99">
           <characteristics>
-            <characteristic name="R" typeId="cdb0-8654-6840-1037">&gt;30-45</characteristic>
-            <characteristic name="FP" typeId="5037-1f27-1790-e355">1</characteristic>
-            <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">8</characteristic>
-            <characteristic name="AP" typeId="7a23-0248-2b94-5951">2</characteristic>
-            <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">3</characteristic>
-            <characteristic name="Special Rules" typeId="5aad-137a-8ee2-63fd">Heavy (RS), Blast (5&quot;)</characteristic>
-            <characteristic name="Traits" typeId="1247-79d2-6cc1-8a03">Conversion</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Heavy conversion beam cannon (Short)" typeId="c591-09ed-3e6f-eb2b" typeName="Ranged Weapon" hidden="false" id="0b2a-63ff-58d7-0a99">
-          <characteristics>
-            <characteristic name="R" typeId="cdb0-8654-6840-1037">&lt;15</characteristic>
+            <characteristic name="R" typeId="cdb0-8654-6840-1037"> 0-15</characteristic>
             <characteristic name="FP" typeId="5037-1f27-1790-e355">1</characteristic>
             <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">6</characteristic>
             <characteristic name="AP" typeId="7a23-0248-2b94-5951">4</characteristic>
@@ -1120,6 +1109,17 @@
             <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">7</characteristic>
             <characteristic name="AP" typeId="7a23-0248-2b94-5951">3</characteristic>
             <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">2</characteristic>
+            <characteristic name="Special Rules" typeId="5aad-137a-8ee2-63fd">Heavy (RS), Blast (5&quot;)</characteristic>
+            <characteristic name="Traits" typeId="1247-79d2-6cc1-8a03">Conversion</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Heavy conversion beam cannon (Long)" typeId="c591-09ed-3e6f-eb2b" typeName="Ranged Weapon" hidden="false" id="2e59-2818-48cb-9067">
+          <characteristics>
+            <characteristic name="R" typeId="cdb0-8654-6840-1037">30-45</characteristic>
+            <characteristic name="FP" typeId="5037-1f27-1790-e355">1</characteristic>
+            <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">8</characteristic>
+            <characteristic name="AP" typeId="7a23-0248-2b94-5951">2</characteristic>
+            <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">3</characteristic>
             <characteristic name="Special Rules" typeId="5aad-137a-8ee2-63fd">Heavy (RS), Blast (5&quot;)</characteristic>
             <characteristic name="Traits" typeId="1247-79d2-6cc1-8a03">Conversion</characteristic>
           </characteristics>


### PR DESCRIPTION
Fixes #1832

<img width="627" height="171" alt="image" src="https://github.com/user-attachments/assets/26436537-887d-4387-9a43-e6651454ce64" />
