### PR TITLE
#2203 - Update the Golden Keshig Champions leadership to correct value

### DIFF
--- a/White Scars.cat
+++ b/White Scars.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="f7b4-2531-0962-1379" name="                         V - White Scars" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="10" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
+<catalogue xmlns="http://www.battlescribe.net/schema/catalogueSchema" library="false" id="f7b4-2531-0962-1379" name="                         V - White Scars" gameSystemId="sys-9fe4-1dc3-b7c2-73cf" gameSystemRevision="1" revision="11" authorUrl="https://github.com/BSData/horus-heresy-3rd-edition/" authorContact="https://github.com/BSData/horus-heresy-3rd-edition/issues" authorName="The4D6" battleScribeVersion="2.03" type="catalogue">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Jaghatai Khan" hidden="false" id="8192-47ac-99f9-73e9" sortIndex="1">
       <selectionEntries>
@@ -806,7 +806,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
                 <characteristic name="W" typeId="f5cc-79a3-d302-cc1d">2</characteristic>
                 <characteristic name="I" typeId="af9d-7db8-dc95-71c1">4</characteristic>
                 <characteristic name="A" typeId="024e-bdb1-7982-25a0">3</characteristic>
-                <characteristic name="LD" typeId="02ad-ebe6-86e7-9fd6">8</characteristic>
+                <characteristic name="LD" typeId="02ad-ebe6-86e7-9fd6">9</characteristic>
                 <characteristic name="CL" typeId="9cd1-0e7c-2cd6-5f2f">8</characteristic>
                 <characteristic name="WP" typeId="f714-1726-37d3-44df">7</characteristic>
                 <characteristic name="IN" typeId="29c5-925d-5b1d-1e77">7</characteristic>


### PR DESCRIPTION
Fixes bug - #2203 

Updated the leadership of the Golden Keshig Champion to 9

<img width="1205" height="179" alt="image" src="https://github.com/user-attachments/assets/b8fbd618-0b2e-451e-84eb-6773d29bbe22" />

<img width="1211" height="188" alt="image" src="https://github.com/user-attachments/assets/606dde68-c186-482c-be9a-1044281f1a95" />
