### PR TITLE
Get rid of Automatic constraints on Warhound Arm weapons as people are too stupid to work out how to use them

### DIFF
--- a/Legio Titanicus.cat
+++ b/Legio Titanicus.cat
@@ -829,8 +829,8 @@
           <selectionEntryGroups>
             <selectionEntryGroup name="Arm weapons" id="c487-e151-9bf5-bdaa" hidden="false">
               <constraints>
-                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="401b-b9e6-735a-defd" automatic="true"/>
-                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="bb72-b11d-c305-abe5" automatic="true"/>
+                <constraint type="min" value="2" field="selections" scope="parent" shared="true" id="401b-b9e6-735a-defd" automatic="false"/>
+                <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="bb72-b11d-c305-abe5" automatic="false"/>
               </constraints>
               <entryLinks>
                 <entryLink import="true" name="Vulcan mega-bolter" hidden="false" id="631a-5104-c494-6f7b" type="selectionEntry" targetId="bdab-7645-227b-1efb" sortIndex="1">


### PR DESCRIPTION
Fixes #2297

<img width="834" height="352" alt="image" src="https://github.com/user-attachments/assets/3a67234e-1713-4e67-b606-775f95518199" />
