### PR TITLE
Add errors for selecting Rite of War specific detachments (WE & EC)

### DIFF
--- a/Emperor's Children.cat
+++ b/Emperor's Children.cat
@@ -2472,6 +2472,9 @@ On any Turn in which they made a Charge Move, Models with this Special Rule gain
               </constraints>
             </selectionEntry>
           </selectionEntries>
+          <categoryLinks>
+            <categoryLink targetId="fbf2-aba8-7792-2f7f" id="cf40-8d3d-bf5b-f3e1" primary="false" name="Legiones Astartes"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Legiones Hereticus Emperor&apos;s Children" hidden="false" id="51f4-9244-2a1c-2d7e">
           <constraints>
@@ -2546,6 +2549,9 @@ After a Shooting Attack that targets a Unit entirely composed of Models with thi
               </conditionGroups>
             </modifier>
           </modifiers>
+          <categoryLinks>
+            <categoryLink targetId="b684-d314-f80b-ee73" id="d812-36a2-e9d2-b0fc" primary="false" name="Legiones Hereticus"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
@@ -2584,6 +2590,11 @@ After a Shooting Attack that targets a Unit entirely composed of Models with thi
               </conditions>
             </conditionGroup>
           </conditionGroups>
+        </modifier>
+        <modifier type="add" value="Brotherhood of the Phoenix only allowed with Legiones Hereticus Rite of War" field="error">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="roster" childId="fbf2-aba8-7792-2f7f" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
         </modifier>
       </modifiers>
       <constraints>

--- a/Horus Heresy 3rd Edition.gst
+++ b/Horus Heresy 3rd Edition.gst
@@ -753,6 +753,8 @@
     <categoryEntry name="Expurgator" id="ac12-7d1f-98e4-2b58" hidden="false"/>
     <categoryEntry name="Vindictor" id="b2d5-2df6-b213-989b" hidden="false"/>
     <categoryEntry name="Scourger" id="b819-ac22-c04b-0932" hidden="false"/>
+    <categoryEntry name="Legiones Astartes" id="fbf2-aba8-7792-2f7f" hidden="false"/>
+    <categoryEntry name="Legiones Hereticus" id="b684-d314-f80b-ee73" hidden="false"/>
   </categoryEntries>
   <forceEntries>
     <forceEntry name="Crusade Force Organization Chart" id="8562-592c-8d4b-a1f0" hidden="false" childForcesLabel="Detachments" sortIndex="2">
@@ -8105,6 +8107,11 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+            <modifier type="add" value="Primacy Wing only allowed with Legiones Astartes Rite of War" field="error">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="b684-d314-f80b-ee73" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <categoryLinks>
             <categoryLink name="Retinue" hidden="false" id="0519-2a37-5f9e-72de" targetId="a38e-50ff-310f-f19e">
@@ -14361,6 +14368,11 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+            <modifier type="add" value="Berserker Cadre only allowed with Legiones Astartes Rite of War" field="error">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="b684-d314-f80b-ee73" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
+            </modifier>
           </modifiers>
           <costs>
             <cost name="Point(s)" typeId="9893-c379-920b-8982" value="0"/>
@@ -15136,6 +15148,11 @@
                   <comment>World Eaters</comment>
                 </conditionGroup>
               </conditionGroups>
+            </modifier>
+            <modifier type="add" value="Sons of Bodt only allowed with Legiones Hereticus Rite of War" field="error">
+              <conditions>
+                <condition type="atLeast" value="1" field="selections" scope="roster" childId="fbf2-aba8-7792-2f7f" shared="true" includeChildSelections="true" includeChildForces="true"/>
+              </conditions>
             </modifier>
           </modifiers>
           <comment>WE</comment>

--- a/World Eaters.cat
+++ b/World Eaters.cat
@@ -2248,6 +2248,9 @@ At the start of the Controlling Player&apos;s Charge Sub-Phase, if there are no 
               </conditionGroups>
             </modifier>
           </modifiers>
+          <categoryLinks>
+            <categoryLink targetId="b684-d314-f80b-ee73" id="a285-b3a8-5fd8-d333" primary="false" name="Legiones Hereticus"/>
+          </categoryLinks>
         </selectionEntry>
         <selectionEntry type="upgrade" import="true" name="Legiones Astartes World Eaters" hidden="false" id="c119-d969-8ad8-a54a">
           <selectionEntries>
@@ -2302,6 +2305,9 @@ On any Turn in which they made a Charge Move, Models with this Special Rule modi
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bbb9-fbb9-426e-2885"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink targetId="fbf2-aba8-7792-2f7f" id="026d-35d2-4204-1a52" primary="false" name="Legiones Astartes"/>
+          </categoryLinks>
         </selectionEntry>
       </selectionEntries>
       <constraints>


### PR DESCRIPTION
Fixes #1999

WE

<img width="1019" height="582" alt="image" src="https://github.com/user-attachments/assets/8582532a-2888-4f48-a2a3-40585de92b63" />

<img width="966" height="581" alt="image" src="https://github.com/user-attachments/assets/05522274-0364-43c1-b4c5-123c4929a738" />


EC

<img width="1098" height="594" alt="image" src="https://github.com/user-attachments/assets/87830976-6424-4fad-a608-992a2c3c3229" />

<img width="956" height="559" alt="image" src="https://github.com/user-attachments/assets/66aab2c5-b14e-4f27-87cf-f50b40bf0429" />
