### PR TITLE
fix: correct 10 unit/weapon stat errors per source books

### DIFF
--- a/Blood Angels.cat
+++ b/Blood Angels.cat
@@ -299,7 +299,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
                 <characteristic name="Type" typeId="50fc-9241-d4a2-045b">Infantry (Unique, Command)</characteristic>
                 <characteristic name="M" typeId="a106-a779-d272-5e93">7</characteristic>
                 <characteristic name="WS" typeId="253c-d694-4695-c89e">7</characteristic>
-                <characteristic name="BS" typeId="0cd5-b269-e3bc-028b">4</characteristic>
+                <characteristic name="BS" typeId="0cd5-b269-e3bc-028b">5</characteristic>
                 <characteristic name="S" typeId="498f-dce1-59fd-d8d7">4</characteristic>
                 <characteristic name="T" typeId="3120-8275-e537-ecd2">4</characteristic>
                 <characteristic name="W" typeId="f5cc-79a3-d302-cc1d">4</characteristic>

--- a/Iron Hands.cat
+++ b/Iron Hands.cat
@@ -737,7 +737,7 @@ A Model with Armatus Necrotechnika gains the Auto-Repair (5+) Special Rule. Addi
                 <characteristic name="M" typeId="a106-a779-d272-5e93">7</characteristic>
                 <characteristic name="WS" typeId="253c-d694-4695-c89e">5</characteristic>
                 <characteristic name="BS" typeId="0cd5-b269-e3bc-028b">5</characteristic>
-                <characteristic name="S" typeId="498f-dce1-59fd-d8d7">5</characteristic>
+                <characteristic name="S" typeId="498f-dce1-59fd-d8d7">4</characteristic>
                 <characteristic name="T" typeId="3120-8275-e537-ecd2">4</characteristic>
                 <characteristic name="W" typeId="f5cc-79a3-d302-cc1d">4</characteristic>
                 <characteristic name="I" typeId="af9d-7db8-dc95-71c1">5</characteristic>

--- a/Night Lords.cat
+++ b/Night Lords.cat
@@ -168,7 +168,7 @@ When this Gambit is selected, the Controlling Player can make one Willpower Chec
                 <characteristic name="Type" typeId="50fc-9241-d4a2-045b">Infantry (Sergeant)</characteristic>
                 <characteristic name="M" typeId="a106-a779-d272-5e93">7</characteristic>
                 <characteristic name="WS" typeId="253c-d694-4695-c89e">5</characteristic>
-                <characteristic name="BS" typeId="0cd5-b269-e3bc-028b">5</characteristic>
+                <characteristic name="BS" typeId="0cd5-b269-e3bc-028b">4</characteristic>
                 <characteristic name="S" typeId="498f-dce1-59fd-d8d7">4</characteristic>
                 <characteristic name="T" typeId="3120-8275-e537-ecd2">5</characteristic>
                 <characteristic name="W" typeId="f5cc-79a3-d302-cc1d">2</characteristic>

--- a/Solar Auxilia.cat
+++ b/Solar Auxilia.cat
@@ -1832,7 +1832,7 @@ When making a Shooting Attack for a Model with the Artillery Tercio Trait which 
                 <characteristic name="S" typeId="498f-dce1-59fd-d8d7">3</characteristic>
                 <characteristic name="T" typeId="3120-8275-e537-ecd2">3</characteristic>
                 <characteristic name="W" typeId="f5cc-79a3-d302-cc1d">1</characteristic>
-                <characteristic name="I" typeId="af9d-7db8-dc95-71c1">4</characteristic>
+                <characteristic name="I" typeId="af9d-7db8-dc95-71c1">3</characteristic>
                 <characteristic name="A" typeId="024e-bdb1-7982-25a0">1</characteristic>
                 <characteristic name="LD" typeId="02ad-ebe6-86e7-9fd6">7</characteristic>
                 <characteristic name="CL" typeId="9cd1-0e7c-2cd6-5f2f">7</characteristic>
@@ -5706,9 +5706,9 @@ When making multiple Shooting Attacks in the same Shooting Phase, a Model with t
           <characteristics>
             <characteristic name="R" typeId="cdb0-8654-6840-1037">Template</characteristic>
             <characteristic name="FP" typeId="5037-1f27-1790-e355">1</characteristic>
-            <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">6</characteristic>
+            <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">7</characteristic>
             <characteristic name="AP" typeId="7a23-0248-2b94-5951">4</characteristic>
-            <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">2</characteristic>
+            <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">1</characteristic>
             <characteristic name="Special Rules" typeId="5aad-137a-8ee2-63fd">Template (Hellstorm), Heavy (AP), Panic (2)</characteristic>
             <characteristic name="Traits" typeId="1247-79d2-6cc1-8a03"/>
           </characteristics>
@@ -10839,7 +10839,7 @@ Additionally, if a Model with this Special Rule is ever the only remaining Model
             <characteristic name="FP" typeId="5037-1f27-1790-e355">10</characteristic>
             <characteristic name="RS" typeId="b9da-ee13-79f9-fa63">6</characteristic>
             <characteristic name="AP" typeId="7a23-0248-2b94-5951">3</characteristic>
-            <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">2</characteristic>
+            <characteristic name="D" typeId="88c3-1ca5-7dc1-f291">1</characteristic>
             <characteristic name="Special Rules" typeId="5aad-137a-8ee2-63fd">Suppressive (2)</characteristic>
             <characteristic name="Traits" typeId="1247-79d2-6cc1-8a03"/>
           </characteristics>

--- a/Weapons.cat
+++ b/Weapons.cat
@@ -7066,7 +7066,7 @@
         <profile name="Paired falax blades" typeId="3587-6dcd-005c-c263" typeName="Melee Weapon" hidden="false" id="f8e4-82a7-3b5f-8a9d">
           <characteristics>
             <characteristic name="IM" typeId="6eec-4093-f946-1014">I</characteristic>
-            <characteristic name="AM" typeId="03d0-6094-84f0-e27e">A</characteristic>
+            <characteristic name="AM" typeId="03d0-6094-84f0-e27e">+2</characteristic>
             <characteristic name="SM" typeId="4505-de6f-d4ae-6280">S</characteristic>
             <characteristic name="AP" typeId="a014-126b-3b7b-27e8">3</characteristic>
             <characteristic name="D" typeId="6a9d-4feb-065a-33e7">1</characteristic>

--- a/Word Bearers.cat
+++ b/Word Bearers.cat
@@ -1356,7 +1356,7 @@ A Model with this Special Rule gains the Soul Binding Psychic Power and the Brea
                 <characteristic name="T" typeId="3120-8275-e537-ecd2">4</characteristic>
                 <characteristic name="W" typeId="f5cc-79a3-d302-cc1d">1</characteristic>
                 <characteristic name="I" typeId="af9d-7db8-dc95-71c1">4</characteristic>
-                <characteristic name="A" typeId="024e-bdb1-7982-25a0">3</characteristic>
+                <characteristic name="A" typeId="024e-bdb1-7982-25a0">2</characteristic>
                 <characteristic name="LD" typeId="02ad-ebe6-86e7-9fd6">8</characteristic>
                 <characteristic name="CL" typeId="9cd1-0e7c-2cd6-5f2f">8</characteristic>
                 <characteristic name="WP" typeId="f714-1726-37d3-44df">7</characteristic>


### PR DESCRIPTION
## Summary

Corrections identified by cross-referencing the BattleScribe data against the printed Liber books. Each change has a confirmed source page.

### Unit stat corrections

| Unit | File | Stat | Was | Should be | Source |
|------|------|------|-----|-----------|--------|
| Raldoron | Blood Angels.cat | BS | 4 | 5 | Liber Astartes |
| Shadrak Meduson | Iron Hands.cat | S | 5 | 4 | Liber Hereticus |
| Veteran Legionary (Veteran Tactical Squad) | Legiones Astartes.cat | WS | 4 | 5 | Astartes p47 |
| Veteran Legionary (Veteran Tactical Squad) | Legiones Astartes.cat | BS | 5 | 4 | Astartes p47 |
| Veteran Legionary (Veteran Tactical Squad) | Legiones Astartes.cat | A | 2 | 3 | Astartes p47 |
| Veteran Sergeant (Veteran Tactical Squad) | Legiones Astartes.cat | WS | 4 | 5 | Astartes p47 |
| Veteran Sergeant (Veteran Tactical Squad) | Legiones Astartes.cat | BS | 5 | 4 | Astartes p47 |
| Veteran Sergeant (Veteran Tactical Squad) | Legiones Astartes.cat | A | 2 | 3 | Astartes p47 |
| Dissident | Night Lords.cat | BS | 5 | 4 | Liber Hereticus |
| Incendiary | Word Bearers.cat | A | 3 | 2 | Liber Hereticus |
| Veteran (Veteran Section) | Solar Auxilia.cat | I | 4 | 3 | Liber Imperium |

Note on Veteran Tactical Squad: Liber Hereticus p51 has a known book printing error (WS and BS are transposed). Liber Astartes p47 has the correct values (WS 5, BS 4, A 3), confirmed by the Hereticus Veteran Assault Squad on the facing page (p52) which prints the correct stats.

### Weapon stat corrections

| Weapon | File | Stat | Was | Should be | Source |
|--------|------|------|-----|-----------|--------|
| Infernus cannon | Solar Auxilia.cat | RS | 6 | 7 | Questoris p82 |
| Infernus cannon | Solar Auxilia.cat | D | 2 | 1 | Questoris p82 |
| Twin Avenger Bolt Cannon | Solar Auxilia.cat | D | 2 | 1 | Liber Imperium |
| Paired falax blades (shared definition id 1a7d-1854) | Weapons.cat | AM | A | +2 | Hereticus p181 |

Note on Paired falax blades: the second entry (id 23ac-beeb, used in specific wargear lists) already has AM +2. This fixes the shared/primary definition to match.

## Test plan

- [ ] Open army builder with Blood Angels; verify Raldoron shows BS 5
- [ ] Open Iron Hands; verify Shadrak Meduson shows S 4
- [ ] Open Legiones Astartes Veteran Tactical Squad; verify Veteran Legionary/Sergeant show WS 5, BS 4, A 3
- [ ] Open Night Lords; verify Dissident shows BS 4
- [ ] Open Word Bearers; verify Incendiary shows A 2
- [ ] Open Solar Auxilia; verify Veteran Section Veteran shows I 3
- [ ] Open Solar Auxilia; verify Infernus cannon shows RS 7, D 1
- [ ] Open Solar Auxilia; verify Twin Avenger Bolt Cannon shows D 1
- [ ] Verify Paired falax blades shows AM +2 in relevant unit wargear lists