### PR TITLE
Give Praetor Frag & Krak

### DIFF
--- a/Dark Angels.cat
+++ b/Dark Angels.cat
@@ -3127,7 +3127,7 @@ the Order</characteristic>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0757-acc7-b785-d758" includeChildSelections="false"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="74f6-fc86-a1b4-215a" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="74f6-fc86-a1b4-215a" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="01e7-bfd8-2d92-f1d9" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="408a-2c9b-7774-1454" includeChildSelections="false"/>

--- a/Imperial Fists.cat
+++ b/Imperial Fists.cat
@@ -111,7 +111,7 @@ Death&apos;s Champion: If this Gambit is selected, attacks made by this Model in
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0c56-f6ff-2ce8-9b63" includeChildSelections="false"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="df0b-052a-4fe3-2910" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="df0b-052a-4fe3-2910" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8221-77aa-faea-81bb" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3613-7316-cc83-442f" includeChildSelections="false"/>
@@ -265,7 +265,7 @@ Death&apos;s Champion: If this Gambit is selected, attacks made by this Model in
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="a8fd-ab02-1283-28be" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="a8fd-ab02-1283-28be" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3724-1e9b-3f54-06a8-min" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3724-1e9b-3f54-06a8-max" includeChildSelections="false"/>
@@ -815,7 +815,7 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
         </rule>
       </rules>
       <entryLinks>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="e32b-a5a6-983e-3d53" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="6">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="e32b-a5a6-983e-3d53" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="6">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9d18-5b87-56d6-ca48" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="eef1-fe8c-dca5-0b63" includeChildSelections="false"/>
@@ -935,7 +935,7 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f632-e9be-d026-acfa-max" includeChildSelections="false"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="bc7c-b633-6396-0049" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="bc7c-b633-6396-0049" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e002-b619-174c-de35-min" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e002-b619-174c-de35-max" includeChildSelections="false"/>
@@ -1068,7 +1068,7 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8f7d-479d-dabe-7e4f" includeChildSelections="false"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="7895-7d0d-4cd4-7de8" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="7895-7d0d-4cd4-7de8" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b288-aab0-9eb9-385e" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3274-122b-9c7f-aa2c" includeChildSelections="false"/>
@@ -1367,7 +1367,7 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
         </rule>
       </rules>
       <entryLinks>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="95b6-40a9-3808-5c64" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="95b6-40a9-3808-5c64" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d754-71be-7402-1c06" includeChildSelections="false"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3da8-afe7-6a5d-31f8" includeChildSelections="false"/>
@@ -1478,7 +1478,7 @@ Prepared Defenses: Until the end of the first Battle Turn of the Battle, all Mod
             </infoLink>
           </infoLinks>
           <entryLinks>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="51fa-e4e7-fc5a-d50d" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="51fa-e4e7-fc5a-d50d" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="78e2-bd6d-1923-15c2-min" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="78e2-bd6d-1923-15c2-max" includeChildSelections="false"/>

--- a/Solar Auxilia.cat
+++ b/Solar Auxilia.cat
@@ -2760,7 +2760,7 @@ When making a Shooting Attack for a Model with the Artillery Tercio Trait which 
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a0c3-6645-391e-484d"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="4230-bc71-cdb6-a795" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="4230-bc71-cdb6-a795" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c586-8148-aad3-86b7"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fc8b-2f5c-39b5-5ae8"/>
@@ -9351,7 +9351,7 @@ A Model with this Special Rule has the Navis Astrologis Psychic Discipline, gain
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2c95-5510-e0ae-737c"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="6205-9e96-cf40-1ced" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="6205-9e96-cf40-1ced" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cfa7-be3b-1414-7da9"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ec45-32f2-ce12-e028"/>
@@ -10618,7 +10618,7 @@ Additionally, if a Model with this Special Rule is ever the only remaining Model
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8e4b-4fcf-ffd1-4096"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="3979-9c2d-dfc1-9b13" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="3979-9c2d-dfc1-9b13" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0c27-700d-1505-6ab4"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b75-edfd-76a8-f777"/>

--- a/Sons of Horus.cat
+++ b/Sons of Horus.cat
@@ -412,7 +412,7 @@ If a Model with this Special Rule joins a Justaerin Terminator Squad Unit in Res
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="35ac-71a7-c9f9-4dce"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="1455-3f3d-ecba-a0b1" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="1455-3f3d-ecba-a0b1" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7a6b-7ed2-6a85-b95d"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8e7-6d5f-5f8f-aee3"/>
@@ -561,7 +561,7 @@ If a Model with this Special Rule joins a Justaerin Terminator Squad Unit in Res
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4885-b0f4-e154-c83a"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="64c6-3e31-eeed-0146" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="6">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="64c6-3e31-eeed-0146" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="6">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fe3f-6888-f087-37f8"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0747-64d8-c83f-ad8d"/>
@@ -1102,7 +1102,7 @@ A Model with this Special Rule can join Units with the Malefic Sub-Type as if it
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d767-4a72-6055-ca1f"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="e962-5fcf-fa6e-0b49" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="e962-5fcf-fa6e-0b49" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6575-f48c-80dc-a75b"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0d54-8349-9ca2-0302"/>
@@ -1210,7 +1210,7 @@ The Controlling Player of a Model with this Special Rule gains 2 Victory Points 
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6358-db16-a776-16ae"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="06f2-4fc8-c23b-5b69" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="06f2-4fc8-c23b-5b69" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d79-b943-9ca9-0b45"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6415-6a72-857d-5c02"/>
@@ -1357,7 +1357,7 @@ If the Wounds Characteristic of a Model with this Special Rule is reduced to 0 o
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d48e-0c5e-7074-4b2b"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="461e-7185-7f2d-60da" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="6">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="461e-7185-7f2d-60da" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="6">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="614b-cdc6-1e3a-19e7"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d398-b3b5-e3f3-9360"/>
@@ -1759,7 +1759,7 @@ If the Wounds Characteristic of a Model with this Special Rule is reduced to 0 o
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d442-06ee-759c-1fca"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="6343-9370-5db1-2c73" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="6343-9370-5db1-2c73" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="91ed-ecf7-7ec9-37bc"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="76f0-50bc-6563-3e5e"/>
@@ -1862,7 +1862,7 @@ If the Wounds Characteristic of a Model with this Special Rule is reduced to 0 o
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3edc-dc58-5a30-2711"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="92ec-5874-00c8-32e3" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="6">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="92ec-5874-00c8-32e3" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="6">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="be4e-39e9-c053-3aa9"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d5d8-95d1-6b90-13fb"/>
@@ -2665,7 +2665,7 @@ Each time an enemy Model declares a Challenge, the Controlling Player of a Model
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c616-3b15-986d-7d3a"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="02ad-748c-ee4f-9b14" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="02ad-748c-ee4f-9b14" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f3dd-5cd7-e205-2259"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e9a1-40d0-2243-ec75"/>

--- a/Space Wolves.cat
+++ b/Space Wolves.cat
@@ -342,7 +342,7 @@ Howl of the Death Wolf: Once this Gambit is selected and until it&apos;s effects
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="31cb-c878-a9f5-d90d"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="bafc-0571-7dba-5725" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="bafc-0571-7dba-5725" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="13f7-292f-4b0b-8606"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9086-ca0d-3fa9-2301"/>
@@ -866,7 +866,7 @@ Howl of the Death Wolf: Once this Gambit is selected and until it&apos;s effects
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8086-8420-867e-f110"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="269d-19eb-653b-7fba" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="269d-19eb-653b-7fba" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4a62-b267-c063-4844"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b5b9-cf86-daeb-7d87"/>
@@ -1574,7 +1574,7 @@ Head-taker: If this Gambit is selected, the Opposing Player may not claim an Out
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2a0c-0bad-0d70-464a"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="84ec-a2cd-48cc-e000" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="6">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="84ec-a2cd-48cc-e000" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="6">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a060-5e22-1458-993a"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bc93-e041-bf97-5421"/>

--- a/Ultramarines.cat
+++ b/Ultramarines.cat
@@ -70,7 +70,7 @@
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5cab-c95d-1f89-3bba"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="a7fe-0ab7-3cec-1af6" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="a7fe-0ab7-3cec-1af6" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8347-87f4-c34c-7c00"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4aef-6fc9-13ee-f3cf"/>
@@ -212,7 +212,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a109-b155-96d8-f279"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="42dd-1b01-e6c8-41ef" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="7">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="42dd-1b01-e6c8-41ef" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="7">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="58d7-9189-1a15-fc46"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ac27-f0ac-17e8-3cc0"/>
@@ -365,7 +365,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9e36-41a3-2e53-6cf8"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="0502-06e9-2597-15cc" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="0502-06e9-2597-15cc" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a7bf-54cf-441d-419d"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4e34-75c6-47e0-4794"/>
@@ -670,7 +670,7 @@ During the Statuses Sub-Phase, any friendly Unit that does not include a Model w
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7f3c-f6dc-3398-a376"/>
           </constraints>
         </entryLink>
-        <entryLink import="true" name="Krak grenades" hidden="false" id="dd81-1147-64f5-a208" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+        <entryLink import="true" name="Krak grenades" hidden="false" id="dd81-1147-64f5-a208" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
           <constraints>
             <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5101-37df-669e-2262"/>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7b7f-a1c3-59a3-3fa8"/>

--- a/Weapons.cat
+++ b/Weapons.cat
@@ -9055,24 +9055,6 @@
         </infoLink>
       </infoLinks>
     </selectionEntry>
-    <selectionEntry type="upgrade" import="true" name="Krak grenades" hidden="false" id="0c9b-a32b-87e2-fc3e">
-      <profiles>
-        <profile name="Krak grenades" typeId="3587-6dcd-005c-c263" typeName="Melee Weapon" hidden="false" id="cddf-d43f-491d-49c1">
-          <characteristics>
-            <characteristic name="IM" typeId="6eec-4093-f946-1014">-3</characteristic>
-            <characteristic name="AM" typeId="03d0-6094-84f0-e27e">1</characteristic>
-            <characteristic name="SM" typeId="4505-de6f-d4ae-6280">6</characteristic>
-            <characteristic name="AP" typeId="a014-126b-3b7b-27e8">4</characteristic>
-            <characteristic name="D" typeId="6a9d-4feb-065a-33e7">2</characteristic>
-            <characteristic name="Special Rules" typeId="ebe0-7b28-b40c-694e">Detonation</characteristic>
-            <characteristic name="Traits" typeId="76e3-c188-bc65-3467">-</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink name="Detonation" id="cf16-be3a-4023-1659" hidden="false" type="rule" targetId="7349-9e80-c051-c22f"/>
-      </infoLinks>
-    </selectionEntry>
     <selectionEntry type="upgrade" import="true" name="Mole mortar" hidden="false" id="9e9c-1b29-e830-f697">
       <profiles>
         <profile name="Mole mortar" typeId="c591-09ed-3e6f-eb2b" typeName="Ranged Weapon" hidden="false" id="d7bf-641e-3a9c-aee5">

--- a/White Scars.cat
+++ b/White Scars.cat
@@ -363,7 +363,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="842f-503e-8323-a9dd" includeChildSelections="false"/>
           </constraints>
           <entryLinks>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="0593-a4a1-f233-03f7" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="0593-a4a1-f233-03f7" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="66e1-2ff3-2baa-a22a"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="85ef-b2df-f6b1-c54f"/>
@@ -562,7 +562,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="935b-81f7-bf5a-b007"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="0e78-07e7-2410-0892" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="0e78-07e7-2410-0892" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4a18-3fc1-fe21-d3f2"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6cf6-a66c-a909-3f18"/>
@@ -1377,7 +1377,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5585-5c38-7380-c171"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="cea5-e8b1-1931-400d" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="cea5-e8b1-1931-400d" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6cc4-2bc4-db87-3fa0"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c2e5-f63c-ad51-a329"/>
@@ -1513,7 +1513,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8458-b75b-9431-a43a"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="2e29-c759-075f-2e93" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="2e29-c759-075f-2e93" type="selectionEntry" targetId="fa20-82bc-c7de-9e97">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4b18-9e73-6e7f-4d54"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6232-3366-dbdf-784e"/>
@@ -1668,7 +1668,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="840c-3c71-f4e3-a347" includeChildSelections="false"/>
           </constraints>
           <entryLinks>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="735e-78a4-82d6-6985" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="4">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="735e-78a4-82d6-6985" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="4">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c871-5480-e7d9-38a0"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d854-2057-0d5e-9369"/>
@@ -1873,7 +1873,7 @@ Furthermore, if a Model with this Special Rule is part of an Army, then the foll
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f43b-1d89-47df-dff7" includeChildSelections="false"/>
           </constraints>
           <entryLinks>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="c575-dddb-20c1-ee06" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="6">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="c575-dddb-20c1-ee06" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="6">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="200f-1182-9e32-d250"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1bdc-1b81-6920-5faa"/>

--- a/Word Bearers.cat
+++ b/Word Bearers.cat
@@ -663,7 +663,7 @@ A Model with this Special Rule gains the Soul Binding Psychic Power and the Brea
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="558c-b4b8-8ac6-277d-max" includeChildSelections="false"/>
               </constraints>
             </entryLink>
-            <entryLink import="true" name="Krak grenades" hidden="false" id="e6d0-a0cd-d28d-5c1d" type="selectionEntry" targetId="0c9b-a32b-87e2-fc3e" sortIndex="5">
+            <entryLink import="true" name="Krak grenades" hidden="false" id="e6d0-a0cd-d28d-5c1d" type="selectionEntry" targetId="fa20-82bc-c7de-9e97" sortIndex="5">
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ccd9-184f-4892-31bc-min" includeChildSelections="false"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ccd9-184f-4892-31bc-max" includeChildSelections="false"/>


### PR DESCRIPTION
Fixes #2727

Also there were two Krak grenade entries in Weapons.cat - consolidated that down to one entry and re-pointed 39 wrong references.