### PR TITLE
fix: add Heavy Assault Daemon Brute Units Only category Militia

### DIFF
--- a/Imperialis Militia.cat
+++ b/Imperialis Militia.cat
@@ -13667,10 +13667,8 @@ Every Model in a Unit that only includes Models with the Irregulars Special Rule
     <entryLink import="true" name="Ruinstorm Daemon Brutes" hidden="false" id="26c1-c3be-dc54-5286" type="selectionEntry" targetId="fe9c-0eae-59a2-3183">
       <categoryLinks>
         <categoryLink targetId="3235-bd79-e9b1-60fa" id="a60b-b150-b636-112d" primary="true" name="Heavy Assault"/>
+        <categoryLink targetId="3997-20e2-b947-ad8d" id="b3d1-a872-5f49-c012" primary="false" name="Heavy Assault - Daemon Brute Units Only"/>
       </categoryLinks>
-      <modifiers>
-        <modifier type="set-primary" value="3997-20e2-b947-ad8d" field="category"/>
-      </modifiers>
     </entryLink>
     <entryLink import="true" name="Militia Leman Russ Tank" hidden="false" id="98da-550f-7546-5a2a" type="selectionEntry" targetId="186a-9905-43e7-92b8">
       <categoryLinks>


### PR DESCRIPTION
The Auxiliary - Daemonic Manifestation detachment (2733-cda6-ff04-1d79) has a slot for category 3997-20e2-b947-ad8d (Heavy Assault - Daemon Brute Units Only, max 3). The Ruinstorm Daemon Brutes entryLink in this catalogue had a set-primary modifier targeting this category but no explicit categoryLink, leaving the slot empty.

Replace the modifier with an explicit categoryLink so Daemon Brutes fill the slot.